### PR TITLE
better order of flags

### DIFF
--- a/src/geotop/config.h.in
+++ b/src/geotop/config.h.in
@@ -6,16 +6,21 @@
 #ifdef COMPILER_HAS_DIAGNOSTIC_PRAGMA
 #define DISABLE_WARNINGS                                                \
 _Pragma("GCC diagnostic push")                                          \
+_Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")                 \
 _Pragma("GCC diagnostic ignored \"-Wpragmas\"")                         \
+_Pragma("GCC diagnostic ignored \"-Wunknown-warning-option\"")          \
+_Pragma("GCC diagnostic ignored \"-Wunknown-warning\"")                 \
+_Pragma("GCC diagnostic ignored \"-Wextra\"")                           \
 _Pragma("GCC diagnostic ignored \"-Waddress-of-packed-member\"")        \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")         \
 _Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")            \
 _Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")            \
-_Pragma("GCC diagnostic ignored \"-Wextra\"")                           \
 _Pragma("GCC diagnostic ignored \"-Wignored-attributes\"")              \
 _Pragma("GCC diagnostic ignored \"-Wignored-qualifiers\"")              \
 _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")            \
 _Pragma("GCC diagnostic ignored \"-Winfinite-recursion\"")              \
+_Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")          \
+_Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")      \
 _Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")                \
 _Pragma("GCC diagnostic ignored \"-Woverflow\"")                        \
 _Pragma("GCC diagnostic ignored \"-Woverloaded-virtual\"")              \
@@ -24,9 +29,6 @@ _Pragma("GCC diagnostic ignored \"-Wstrict-aliasing\"")                 \
 _Pragma("GCC diagnostic ignored \"-Wtautological-constant-out-of-range-compare\"") \
 _Pragma("GCC diagnostic ignored \"-Wtype-limits\"")                     \
 _Pragma("GCC diagnostic ignored \"-Wundef\"")                           \
-_Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")                 \
-_Pragma("GCC diagnostic ignored \"-Wunknown-warning-option\"")          \
-_Pragma("GCC diagnostic ignored \"-Wunknown-warning\"")                 \
 _Pragma("GCC diagnostic ignored \"-Wunused-but-set-parameter\"")        \
 _Pragma("GCC diagnostic ignored \"-Wunused-but-set-variable\"")         \
 _Pragma("GCC diagnostic ignored \"-Wunused-function\"")                 \


### PR DESCRIPTION
order of the flags is important for disabling warnings from the inclusion of external libraries e.g. MeteoIO, Boost.

I compiled on my machine with both gcc-6 and clang-5 (I do not know the corresponding version on mac)

if you have some warnings, please open an issue with the output of compilation and I'll try to fix that