### PR TITLE
small improvement on reading input files

### DIFF
--- a/src/geotop/output_file.cc
+++ b/src/geotop/output_file.cc
@@ -266,7 +266,7 @@ namespace geotop
 
     std::string OutputFile::getFileName(double dateeur12, long layer)
     {
-      char buffer[13] = {'\0'};
+      char buffer[17] = {'\0'};
       std::string output;
       long day = 0L, month = 0L, year = 0L, hour = 0L, min = 0L;
 
@@ -329,7 +329,7 @@ namespace geotop
       output.append("_");
 
       // Period
-      memset(buffer, 0, 13);
+      memset(buffer, 0, 16);
 
       if (mPeriod > 0 && mPeriod < 60) sprintf(buffer, "%.2lds", mPeriod);
 
@@ -347,7 +347,7 @@ namespace geotop
       if (layer != -1 && mDimension != D1Dp && mDimension != D1Ds)
         {
           output.append("_L");
-          memset(buffer, 0, 13);
+          memset(buffer, 0, 16);
           sprintf(buffer, "%.4ld", layer);
           output.append(buffer);
         }

--- a/src/libraries/ascii/tabs.cc
+++ b/src/libraries/ascii/tabs.cc
@@ -42,8 +42,8 @@
 /*============================================================================*/
 /*                               Constants                                    */
 /*============================================================================*/
-const long max_components = 200;
-const long max_string_length = 200;
+constexpr long max_components = 200;
+constexpr long max_string_length = 200;
 
 /*============================================================================*/
 /*                      Private functions prototypes                          */
@@ -223,7 +223,7 @@ long *find_string_int(long *vector, long lengthvector)
 static short readline(FILE *f,
                       long comment_char,
                       long sep_char,
-                      long **string,
+                      long *string,
                       long *string_length,
                       long *components,
                       long maxcomponents,
@@ -243,7 +243,7 @@ static short readline(FILE *f,
 
       for (j = 0; j < maxstringlength; j++)
         {
-          string[i][j] = 0;
+          string[i*maxstringlength +j] = 0;
         }
     }
 
@@ -295,7 +295,7 @@ static short readline(FILE *f,
 
           if (j == 0)
             {
-              string[j][i] = c[0];
+              string[j*maxstringlength +i] = c[0];
               i++;
             }
 
@@ -315,7 +315,7 @@ static short readline(FILE *f,
                 {
                   if (i < maxstringlength)
                     {
-                      string[j][i] = c[0];
+                      string[j*maxstringlength +i] = c[0];
                       i++;
                     }
                 }
@@ -345,18 +345,19 @@ static std::vector<std::string> readline_of_strings(FILE *f,
                                                     short *success)
 {
   long i, n;
-  long **string, *string_length;
+  long string[max_components*max_string_length];
+  long string_length[max_components];
   std::vector<std::string> line_of_strings;
 
   n = max_components;
-  string_length = (long *)alloca(n * sizeof(long));
-  string = (long **)alloca(n * sizeof(long *));
+  // string_length = (long *)alloca(n * sizeof(long));
+  // string = (long **)alloca(n * sizeof(long *));
 
-  n = max_string_length;
-  for (i = 0; i < max_components; i++)
-    {
-      string[i] = (long *)alloca(n * sizeof(long));
-    }
+  // n = max_string_length;
+  // for (i = 0; i < max_components; i++)
+  //   {
+  //     string[i] = (long *)alloca(n * sizeof(long));
+  //   }
 
   *success = readline(f, comment_char, sep_char, string, string_length,
                       components, max_components, max_string_length, endoffile);
@@ -365,7 +366,16 @@ static std::vector<std::string> readline_of_strings(FILE *f,
     {
       for (i = 0; i < (*components); i++)
         {
-          line_of_strings.push_back(find_string(string[i], string_length[i]));
+	  std::stringstream stream;
+	  
+	  for (int j = 0; j < string_length[i]; ++j)
+	    {
+	      stream << char(string[i*max_string_length+j]);
+	    }
+
+
+          // line_of_strings.push_back(find_string(string[i], string_length[i]));
+          line_of_strings.push_back(stream.str());
         }
     }
 
@@ -388,18 +398,19 @@ static double *readline_of_numbers(FILE *f,
                                    short *success)
 {
   long i, n;
-  long **string, *string_length;
+  long string[max_components*max_string_length];
+  long string_length[max_components];
   double *line_of_numbers = NULL;
 
   n = max_components;
-  string_length = (long *)alloca(n * sizeof(long));
-  string = (long **)alloca(n * sizeof(long *));
+  // string_length = (long *)alloca(n * sizeof(long));
+  // string = (long **)alloca(n * sizeof(long *));
 
   n = max_string_length;
-  for (i = 0; i < max_components; i++)
-    {
-      string[i] = (long *)alloca(n * sizeof(long));
-    }
+  // for (i = 0; i < max_components; i++)
+  //   {
+  //     string[i] = (long *)alloca(n * sizeof(long));
+  //   }
 
   *success = readline(f, comment_char, sep_char, string, string_length,
                       components, max_components, max_string_length, endoffile);
@@ -410,7 +421,7 @@ static double *readline_of_numbers(FILE *f,
 
       for (i = 0; i < (*components); i++)
         {
-          line_of_numbers[i] = find_number(string[i], string_length[i]);
+          line_of_numbers[i] = find_number(&string[i*max_string_length], string_length[i]);
         }
     }
 

--- a/src/libraries/ascii/tabs.cc
+++ b/src/libraries/ascii/tabs.cc
@@ -231,7 +231,8 @@ static short readline(FILE *f,
                       short *endoffile)
 {
   long i, j;
-  char *c;
+  char cc;
+  char *c = &cc;
 
   *endoffile = 0;
 
@@ -247,7 +248,7 @@ static short readline(FILE *f,
     }
 
   // allocate character
-  c = (char *)malloc(sizeof(char));
+  // c = (char *)malloc(sizeof(char));
 
   // read first character
   do
@@ -263,7 +264,7 @@ static short readline(FILE *f,
   // end of file reached
   if (*endoffile == 1)
     {
-      free(c);
+      // free(c);
       return -1;
 
       // first character is the comment tag
@@ -279,7 +280,7 @@ static short readline(FILE *f,
 
       if (c[0] == -1) *endoffile = 1;
 
-      free(c);
+      // free(c);
       return -1;
 
     }
@@ -331,7 +332,7 @@ static short readline(FILE *f,
 
       *components = j;
 
-      free(c);
+      // free(c);
       return 1;
     }
 }
@@ -348,13 +349,13 @@ static std::vector<std::string> readline_of_strings(FILE *f,
   std::vector<std::string> line_of_strings;
 
   n = max_components;
-  string_length = (long *)malloc(n * sizeof(long));
-  string = (long **)malloc(n * sizeof(long *));
+  string_length = (long *)alloca(n * sizeof(long));
+  string = (long **)alloca(n * sizeof(long *));
 
   n = max_string_length;
   for (i = 0; i < max_components; i++)
     {
-      string[i] = (long *)malloc(n * sizeof(long));
+      string[i] = (long *)alloca(n * sizeof(long));
     }
 
   *success = readline(f, comment_char, sep_char, string, string_length,
@@ -368,13 +369,13 @@ static std::vector<std::string> readline_of_strings(FILE *f,
         }
     }
 
-  for (i = 0; i < max_components; i++)
-    {
-      free(string[i]);
-    }
+  // for (i = 0; i < max_components; i++)
+  //   {
+  //     free(string[i]);
+  //   }
 
-  free(string_length);
-  free(string);
+  // free(string_length);
+  // free(string);
 
   return line_of_strings;
 }
@@ -391,13 +392,13 @@ static double *readline_of_numbers(FILE *f,
   double *line_of_numbers = NULL;
 
   n = max_components;
-  string_length = (long *)malloc(n * sizeof(long));
-  string = (long **)malloc(n * sizeof(long *));
+  string_length = (long *)alloca(n * sizeof(long));
+  string = (long **)alloca(n * sizeof(long *));
 
   n = max_string_length;
   for (i = 0; i < max_components; i++)
     {
-      string[i] = (long *)malloc(n * sizeof(long));
+      string[i] = (long *)alloca(n * sizeof(long));
     }
 
   *success = readline(f, comment_char, sep_char, string, string_length,
@@ -413,13 +414,13 @@ static double *readline_of_numbers(FILE *f,
         }
     }
 
-  for (i = 0; i < max_components; i++)
-    {
-      free(string[i]);
-    }
+  // for (i = 0; i < max_components; i++)
+  //   {
+  //     free(string[i]);
+  //   }
 
-  free(string_length);
-  free(string);
+  // free(string_length);
+  // free(string);
 
   return line_of_numbers;
 }


### PR DESCRIPTION
I started profiling some 1D tests and I found that considerable amount of time was spent in `malloc` and `free` when reading files. Since the sizes of the `malloc`ed variables are small, we can safely leave them  in the stack. With this PR, the reading part is two times faster 