### PR TITLE
force python2 for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,7 +408,7 @@ foreach(TEST ${1DTESTS})
 	#testing with test_runner
 	add_test(NAME "1D.test_runner.${TEST}"
          WORKING_DIRECTORY ${1D_DIRECTORY}/${TEST}
-	 COMMAND python ${TEST_RUNNER} )
+	 COMMAND python2 ${TEST_RUNNER} )
  	
  	set_tests_properties(
 		"1D.test_runner.${TEST}" PROPERTIES
@@ -423,7 +423,7 @@ foreach(TEST ${3DTESTS})
 	#testing with test_runner
 	add_test(NAME "3D.test_runner.${TEST}"
          WORKING_DIRECTORY ${3D_DIRECTORY}/${TEST}
-	 COMMAND python ${TEST_RUNNER} )
+	 COMMAND python2 ${TEST_RUNNER} )
  	
  	set_tests_properties(
 		"3D.test_runner.${TEST}" PROPERTIES


### PR DESCRIPTION
Our testsuite works only with python2, so we'd better explicitly call it