### PR TITLE
introduce meson build system [skip ci]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,7 @@ IF(ENABLE_INTERNAL_METEODISTR)
 ELSE(ENABLE_INTERNAL_METEODISTR)
      SET ( METEOIOPREFIX on )
 ENDIF(ENABLE_INTERNAL_METEODISTR)
-configure_file (${GEOTOP_TEST_DIR}/test_runner.py.cmake.in ${GEOTOP_TEST_DIR}/test_runner.py)
+configure_file (${GEOTOP_TEST_DIR}/test_runner.py.in ${GEOTOP_TEST_DIR}/test_runner.py @ONLY)
 
 
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,44 @@
+# The meson build system for the geotop project
+# Author: Alberto Sartori (alberto.sartori86@gmail.com) 2018
+
+project('geotop','cpp', 'c',
+        default_options : ['cpp_std=c++11',
+			   'buildtype=release',
+			   'warning_level=3' ],
+        version: '2.1.0')
+
+# the following lists will be populated through the inclusion of the
+# meson.build int the subfolders
+
+# include_dirs : all the folders with the header files
+# src_files    : all the files needed to compile geotop
+# deps         : all the external dependencies required (e.g., boost, meteoio)
+
+# we initialize them as empty lists
+
+include_dirs = []
+src_files    = []
+deps         = []
+
+# rpaths       : all the runpaths, it must be a string
+rpaths       = '/usr/local/lib:/usr/lib:/usr/lib64:/usr/local/lib64'
+
+# find all the source files, main, and include directories
+subdir('src')
+
+# find dependencise, set flags specific for the used compiler,
+# generate config.h and version.h files
+# set up the 'install' target
+subdir('meson')
+
+# the main object is set in a subfolder of src and handles the file
+# where the main is defined
+geotop = executable('geotop', main, src_files,
+                    include_directories: include_dirs,
+                    dependencies: deps,
+                    install:true,
+                    install_rpath: rpaths)
+
+# set up tests
+subdir('tests')
+

--- a/meson/compilers/clang/meson.build
+++ b/meson/compilers/clang/meson.build
@@ -1,0 +1,5 @@
+_bt = get_option('buildtype') 
+if _bt == 'debugoptimized' or _bt == 'release'
+  add_global_arguments('-ffp-contract=fast',
+                       language : ['cpp','c'])
+endif

--- a/meson/compilers/gcc/meson.build
+++ b/meson/compilers/gcc/meson.build
@@ -1,0 +1,1 @@
+# no specific flags are required for now :)

--- a/meson/compilers/intel/meson.build
+++ b/meson/compilers/intel/meson.build
@@ -1,0 +1,5 @@
+_bt = get_option('buildtype') 
+if _bt == 'debugoptimized' or _bt == 'release'
+  add_global_arguments('-fp_speculative=safe',
+                       language : ['cpp','c'])
+endif

--- a/meson/compilers/meson.build
+++ b/meson/compilers/meson.build
@@ -1,0 +1,19 @@
+# to do: other options
+
+
+_bt = get_option('buildtype') 
+if _bt == 'debugoptimized' or _bt == 'release'
+  add_global_arguments(['-funroll-loops',
+                        '-fstrict-aliasing',
+                        '-O2'],
+                       language : ['cpp','c'])
+endif
+
+_supported_compilers = ['clang', 'gcc', 'intel']
+
+foreach _c : _supported_compilers
+    if _cxx.get_id() == _c
+        subdir(_c)
+    endif
+endforeach
+

--- a/meson/config/meson.build
+++ b/meson/config/meson.build
@@ -1,0 +1,47 @@
+include_dirs = [include_dirs, include_directories('.')]
+
+code = '''_Pragma("GCC diagnostic push")
+  _Pragma("GCC diagnostic ignored \"-Wextra\"")
+  _Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")
+  _Pragma("GCC diagnostic ignored \"-Wpragmas\"")
+  int main() { return 0; }
+  _Pragma("GCC diagnostic pop")
+'''
+
+_pragma = _cxx.compiles(code, name: 'pragma check')
+
+_cdata = configuration_data()
+
+_cdata.set('COMPILER_HAS_DIAGNOSTIC_PRAGMA', _pragma)
+
+_cdata.set('VERBOSE', get_option('verbose'))
+
+_cdata.set('VERY_VERBOSE', get_option('very_verbose'))
+
+_cdata.set('USE_INTERNAL_METEODISTR', get_option('enable_internal_meteodistr'))
+
+_cdata.set('METEOIO_OUTPUT', get_option('meteoio_output'))
+
+configure_file(output: 'config.h',
+               input: _config,
+               configuration: _cdata)
+
+_cdata = configuration_data()
+
+
+
+_project_git_version = '0'
+# test if we have git and if it we have it, we query the git version
+# of our project
+_git = run_command('which','git')
+if _git.returncode() == 0
+    r = run_command('git', 'describe', '--tags', '--always', '--abbrev=8')
+    _project_git_version = r.stdout().strip()
+    message('Git version: '+_project_git_version)
+endif
+
+_cdata.set_quoted('GEOtop_BUILD_VERSION', _project_git_version)
+_cdata.set_quoted('PACKAGE_STRING', meson.project_name()+' '+meson.project_version())
+
+configure_file(output: 'version.h',
+               configuration: _cdata)

--- a/meson/custom_targets/meson.build
+++ b/meson/custom_targets/meson.build
@@ -1,0 +1,6 @@
+# define indent target for indenting all source files of geotop
+
+_indent = find_program([meson.source_root()+'/utils/meson_indent'], required: false )
+
+run_target('indent',
+           command: _indent)

--- a/meson/dependencies/boost/meson.build
+++ b/meson/dependencies/boost/meson.build
@@ -1,0 +1,7 @@
+deps = [deps, dependency('boost',
+                         modules: ['regex',
+                                   'program_options',
+                                   'filesystem',
+                                   'system',
+                                   'iostreams',
+                                   'unit_test_framework'])]

--- a/meson/dependencies/meson.build
+++ b/meson/dependencies/meson.build
@@ -1,0 +1,2 @@
+subdir('boost')
+subdir('meteoio')

--- a/meson/dependencies/meteoio/meson.build
+++ b/meson/dependencies/meteoio/meson.build
@@ -1,0 +1,12 @@
+
+meteoio_prefix = get_option('meteoio_path')
+
+_meteoio_lib = meteoio_prefix+'/lib'
+
+deps = [deps, _cxx.find_library('meteoio', dirs: _meteoio_lib)]
+rpaths +=  ':'+_meteoio_lib
+
+include_dirs = [include_dirs,
+                include_directories(meteoio_prefix+'/include')]
+
+

--- a/meson/install/meson.build
+++ b/meson/install/meson.build
@@ -1,0 +1,5 @@
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(version: meson.project_version(),
+                 name: meson.project_name(),
+                 description: '''GEOtop is a distributed model of the mass and energy balance of the hydrological cycle, which is applicable to simulations in continuum in small catchments. GEOtop deals with the effects of topography on the interaction between energy balance and hydrological cycle with peculiar solutions. ''')
+

--- a/meson/meson.build
+++ b/meson/meson.build
@@ -1,0 +1,18 @@
+# this variable is useful when finding libraries and for setting the
+# proper flags for the compiler
+_cxx = meson.get_compiler('cpp')
+
+# find and handle all the dependencies
+subdir('dependencies')
+
+# set proper compile flags
+subdir('compilers')
+
+# generate config.h and version.h
+subdir('config')
+
+# custom targets
+subdir('custom_targets')
+
+# install target
+subdir('install')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,10 @@
+option('meteoio_path', type: 'string', value: '/usr/local/',
+       description: 'Root directory where MeteoIO has been installed')
+
+option('build_static', type: 'boolean', value: false)
+option('verbose', type: 'boolean', value: false)
+option('very_verbose', type: 'boolean', value: false)
+option('enable_internal_meteodistr', type: 'boolean', value: true)
+option('meteoio_output', type: 'boolean', value: false,
+       description: 'Enable the use of MeteoIO for output (Experimental)')
+

--- a/src/geotop/Energy/meson.build
+++ b/src/geotop/Energy/meson.build
@@ -1,0 +1,1 @@
+src_files = [src_files, files('energy_class.cc')]

--- a/src/geotop/Glacier/meson.build
+++ b/src/geotop/Glacier/meson.build
@@ -1,0 +1,1 @@
+src_files = [src_files, files('glacier_class.cc')]

--- a/src/geotop/Meteo/meson.build
+++ b/src/geotop/Meteo/meson.build
@@ -1,0 +1,1 @@
+src_files = [src_files, files(['meteo_class.cc', 'meteostations.cc'])]

--- a/src/geotop/Snow/meson.build
+++ b/src/geotop/Snow/meson.build
@@ -1,0 +1,1 @@
+src_files = [src_files, files('snow_class.cc')]

--- a/src/geotop/Soil/meson.build
+++ b/src/geotop/Soil/meson.build
@@ -1,0 +1,1 @@
+src_files = [src_files, files(['soil_class.cc', 'soilstatevar.cc', 'vegstatevar.cc'])]

--- a/src/geotop/Water/meson.build
+++ b/src/geotop/Water/meson.build
@@ -1,0 +1,1 @@
+src_files = [src_files, files('water_class.cc')]

--- a/src/geotop/config.h.in
+++ b/src/geotop/config.h.in
@@ -3,49 +3,6 @@
 
 #cmakedefine COMPILER_HAS_DIAGNOSTIC_PRAGMA
 
-#ifdef COMPILER_HAS_DIAGNOSTIC_PRAGMA
-#define DISABLE_WARNINGS                                                \
-_Pragma("GCC diagnostic push")                                          \
-_Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")                 \
-_Pragma("GCC diagnostic ignored \"-Wpragmas\"")                         \
-_Pragma("GCC diagnostic ignored \"-Wunknown-warning-option\"")          \
-_Pragma("GCC diagnostic ignored \"-Wunknown-warning\"")                 \
-_Pragma("GCC diagnostic ignored \"-Wextra\"")                           \
-_Pragma("GCC diagnostic ignored \"-Waddress-of-packed-member\"")        \
-_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")         \
-_Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")            \
-_Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")            \
-_Pragma("GCC diagnostic ignored \"-Wignored-attributes\"")              \
-_Pragma("GCC diagnostic ignored \"-Wignored-qualifiers\"")              \
-_Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")            \
-_Pragma("GCC diagnostic ignored \"-Winfinite-recursion\"")              \
-_Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")          \
-_Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")      \
-_Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")                \
-_Pragma("GCC diagnostic ignored \"-Woverflow\"")                        \
-_Pragma("GCC diagnostic ignored \"-Woverloaded-virtual\"")              \
-_Pragma("GCC diagnostic ignored \"-Wpedantic\"")                        \
-_Pragma("GCC diagnostic ignored \"-Wstrict-aliasing\"")                 \
-_Pragma("GCC diagnostic ignored \"-Wtautological-constant-out-of-range-compare\"") \
-_Pragma("GCC diagnostic ignored \"-Wtype-limits\"")                     \
-_Pragma("GCC diagnostic ignored \"-Wundef\"")                           \
-_Pragma("GCC diagnostic ignored \"-Wunused-but-set-parameter\"")        \
-_Pragma("GCC diagnostic ignored \"-Wunused-but-set-variable\"")         \
-_Pragma("GCC diagnostic ignored \"-Wunused-function\"")                 \
-_Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")                \
-_Pragma("GCC diagnostic ignored \"-Wunused-private-field\"")            \
-_Pragma("GCC diagnostic ignored \"-Wunused-variable\"")                 \
-_Pragma("GCC diagnostic ignored \"-Wpragmas\"")                         
-
-#define ENABLE_WARNINGS \
-_Pragma("GCC diagnostic pop")
-
-#else
-
-#define DISABLE_WARNINGS
-#define ENABLE_WARNINGS
-
-#endif
-
+#include "warnings.h"
 
 #endif

--- a/src/geotop/config.meson.h.in
+++ b/src/geotop/config.meson.h.in
@@ -1,0 +1,17 @@
+#ifndef geotop_config_h
+#define geotop_config_h
+
+#mesondefine COMPILER_HAS_DIAGNOSTIC_PRAGMA
+
+#mesondefine VERBOSE
+
+#mesondefine VERY_VERBOSE
+
+#mesondefine USE_INTERNAL_METEODISTR
+
+#mesondefine METEOIO_OUTPUT
+
+// macros DISABLE_WARNINGS and ENABLE_WARNINGS
+#include "warnings.h"
+
+#endif

--- a/src/geotop/indices.cc
+++ b/src/geotop/indices.cc
@@ -34,7 +34,7 @@
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-void i_lrc_cont(GeoMatrix<double> &LC, long *** i, GeoMatrix<long> &lrc)
+void i_lrc_cont(GeoMatrix<double> &LC, long  ***i, GeoMatrix<long> &lrc)
 {
   long cont = 0;
   long l, r, c;
@@ -136,7 +136,7 @@ void cont_nonzero_values_matrix2(long *tot,
                                  Channel *cnet,
                                  GeoMatrix<double> &LC,
                                  GeoMatrix<long> &lrc,
-                                 long *** i,
+                                 long  ***i,
                                  long n)
 {
   long j, jj, l, r = 0, c = 0;
@@ -221,7 +221,7 @@ void cont_nonzero_values_matrix3(GeoVector<long> &Lp,
                                  Channel *cnet,
                                  GeoMatrix<double> &LC,
                                  GeoMatrix<long> &lrc,
-                                 long *** i,
+                                 long  ***i,
                                  long n)
 {
   long j, jj, l, r = 0, c = 0;

--- a/src/geotop/indices.h
+++ b/src/geotop/indices.h
@@ -28,7 +28,7 @@
 
 #include "struct.geotop.h"
 
-void i_lrc_cont(GeoMatrix<double> &LC, long *** i, GeoMatrix<long> &lrc);
+void i_lrc_cont(GeoMatrix<double> &LC, long  ***i, GeoMatrix<long> &lrc);
 
 void j_rc_cont(GeoMatrix<double> &LC, long **j, GeoMatrix<long> &rc);
 
@@ -39,7 +39,7 @@ void cont_nonzero_values_matrix2(long *tot,
                                  Channel *cnet,
                                  GeoMatrix<double> &LC,
                                  GeoMatrix<long> &lrc,
-                                 long *** i,
+                                 long  ***i,
                                  long n);
 
 void cont_nonzero_values_matrix3(GeoVector<long> &Lp,
@@ -47,7 +47,7 @@ void cont_nonzero_values_matrix3(GeoVector<long> &Lp,
                                  Channel *cnet,
                                  GeoMatrix<double> &LC,
                                  GeoMatrix<long> &lrc,
-                                 long *** i,
+                                 long  ***i,
                                  long n);
 
 #endif

--- a/src/geotop/meson.build
+++ b/src/geotop/meson.build
@@ -1,0 +1,50 @@
+main = files('geotop.cc')
+_config = files('config.meson.h.in')
+src_files = files('blowingsnow.cc',
+                  'channels.cc',
+                  'clouds.cc',
+                  'deallocate.cc',
+                  'energy.balance.cc',
+                  'geotop_common.cc',
+                  'geotop_common.h',
+                  'global_logger.cc',
+                  'indices.cc',
+                  'input.cc',
+                  'inputKeywords.cc',
+                  'logger.cc',
+                  'meteo.cc',
+                  'meteodata.cc',
+                  'meteodistr.cc',
+                  'output.cc',
+                  'output_file.cc',
+                  'output_new.cc',
+                  'parameters.cc',
+#                  'part_snow.cc',
+                  'PBSM.cc',
+                  'pedo.funct.cc',
+                  'radiation.cc',
+                  'recovering.cc',
+                  'snow.cc',
+                  'standard_names.cc',
+                  'statevar.cc',
+                  'tables.cc',
+                  'times.cc',
+                  'turbulence.cc',
+                  'vegetation.cc',
+                  'water.balance.cc')
+
+
+subdir('Energy')
+subdir('Glacier')
+subdir('Meteo')
+subdir('Snow')
+subdir('Soil')
+subdir('Water')
+
+include_dirs = [include_dirs,
+                include_directories(['Energy',
+                                     'Glacier',
+                                     'Meteo',
+                                     'Snow',
+                                     'Soil',
+                                     'Water'])]

--- a/src/geotop/warnings.h
+++ b/src/geotop/warnings.h
@@ -1,0 +1,43 @@
+#ifdef COMPILER_HAS_DIAGNOSTIC_PRAGMA
+#define DISABLE_WARNINGS                                                \
+  _Pragma("GCC diagnostic push")                                          \
+  _Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")                 \
+  _Pragma("GCC diagnostic ignored \"-Wpragmas\"")                         \
+  _Pragma("GCC diagnostic ignored \"-Wunknown-warning-option\"")          \
+  _Pragma("GCC diagnostic ignored \"-Wunknown-warning\"")                 \
+  _Pragma("GCC diagnostic ignored \"-Wextra\"")                           \
+  _Pragma("GCC diagnostic ignored \"-Waddress-of-packed-member\"")        \
+  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")         \
+  _Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")            \
+  _Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")            \
+  _Pragma("GCC diagnostic ignored \"-Wignored-attributes\"")              \
+  _Pragma("GCC diagnostic ignored \"-Wignored-qualifiers\"")              \
+  _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")            \
+  _Pragma("GCC diagnostic ignored \"-Winfinite-recursion\"")              \
+  _Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")          \
+  _Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")      \
+  _Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")                \
+  _Pragma("GCC diagnostic ignored \"-Woverflow\"")                        \
+  _Pragma("GCC diagnostic ignored \"-Woverloaded-virtual\"")              \
+  _Pragma("GCC diagnostic ignored \"-Wpedantic\"")                        \
+  _Pragma("GCC diagnostic ignored \"-Wstrict-aliasing\"")                 \
+  _Pragma("GCC diagnostic ignored \"-Wtautological-constant-out-of-range-compare\"") \
+  _Pragma("GCC diagnostic ignored \"-Wtype-limits\"")                     \
+  _Pragma("GCC diagnostic ignored \"-Wundef\"")                           \
+  _Pragma("GCC diagnostic ignored \"-Wunused-but-set-parameter\"")        \
+  _Pragma("GCC diagnostic ignored \"-Wunused-but-set-variable\"")         \
+  _Pragma("GCC diagnostic ignored \"-Wunused-function\"")                 \
+  _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")                \
+  _Pragma("GCC diagnostic ignored \"-Wunused-private-field\"")            \
+  _Pragma("GCC diagnostic ignored \"-Wunused-variable\"")                 \
+  _Pragma("GCC diagnostic ignored \"-Wpragmas\"")
+
+#define ENABLE_WARNINGS \
+  _Pragma("GCC diagnostic pop")
+
+#else
+
+#define DISABLE_WARNINGS
+#define ENABLE_WARNINGS
+
+#endif

--- a/src/gt_utilities/meson.build
+++ b/src/gt_utilities/meson.build
@@ -1,0 +1,1 @@
+src_files = [src_files, files(['geomorphology.cc', 'math_utils.cc', 'path_utils.c', 'read_command_line.cc'])]

--- a/src/libraries/ascii/meson.build
+++ b/src/libraries/ascii/meson.build
@@ -1,0 +1,1 @@
+src_files = [src_files, files(['rw_maps.cc', 'tabs.cc'])]

--- a/src/libraries/meson.build
+++ b/src/libraries/meson.build
@@ -1,0 +1,2 @@
+include_dirs = [include_dirs, include_directories('ascii')]
+subdir('ascii')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,10 @@
+include_dirs = [include_dirs,
+                include_directories(['geotop',
+                                     'gt_utilities',
+                                     'libraries',
+                                     'meteoio_plugin'])]
+
+subdir('geotop')
+subdir('gt_utilities')
+subdir('libraries')
+subdir('meteoio_plugin')

--- a/src/meteoio_plugin/meson.build
+++ b/src/meteoio_plugin/meson.build
@@ -1,0 +1,1 @@
+src_files = [src_files, files('meteoioplugin.cc')]

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,86 @@
+_prefix = meson.current_source_dir()
+# list all the tests with the following format
+#     folder/test_name
+# each test will have the following properties:
+# name : 'folder/test_name'
+# suite : ['folder', 'test_name', name]
+
+# you can run a specific test with its name attribute
+#     meson test name
+# i.e.
+#     meson test folder/test_name
+
+# or a set of tests by means of a suite 
+#     meson test --suite geotop:folder
+#     meson test --suite geotop:test_name
+
+_tests = ['1D/B2_BeG_017',
+          '1D/Bro',
+          '1D/Calabria',
+          '1D/ColdelaPorte',
+          '1D/CostantMeteo',
+          '1D/Jungfraujoch',
+          '1D/Matsch_B2_Ref_007',
+          '1D/Matsch_P2_Ref_007',
+          '1D/PureDrainage',
+          '1D/PureDrainageFaked',
+          '1D/PureDrainageRainy',
+          '1D/PureDrainageRainySlope',
+          '3D/Borden05m',
+          '3D/example',
+          '3D/hillslope01',
+          '3D/hillslope02_superslab',
+          '3D/Mazia',
+          '3D/no_reflection',
+          '3D/onepoint_hydrostatic',
+          '3D/panola',
+          '3D/panola_25pixel',
+          '3D/panola_25pixel_nobed',
+          '3D/panola_25pixel_nobed_hydrostatic',
+          '3D/prealpiC',
+          '3D/PSQL_test',
+          '3D/rendena',
+          '3D/small_example',
+          '3D/small_example-channel',
+          '3D/small_example-onlyEnergy',
+          '3D/snow_dstr_SENSITIVITY',
+          '3D/Vshape',
+          '3D/WG1_2.0_001']
+
+foreach _t : _tests
+    _test_prefix = _prefix+'/'+_t
+    _dim = _t.split('/')[0]
+    _name = _t.split('/')[1]
+   test(_t, geotop, args:[_test_prefix], suite: [_dim, _name],
+        timeout: 900)
+endforeach
+
+# setup the test_runner tests. They have an additional suite entry,
+# namely 'test_runner'
+
+_conf_runner = configuration_data()
+_conf_runner.set('GEOTOP_PROGRAM_PATH', meson.build_root()+'/geotop')
+
+_meteoio_status = 'off'
+if get_option('meteoio_output')
+    _meteoio_status = 'on'   
+endif
+_conf_runner.set('METEOIOPREFIX', _meteoio_status)
+
+_conf_runner.set('GEOTOP_TEST_DIR', _prefix)
+
+configure_file(output: 'test_runner.py',
+               input: 'test_runner.py.in',
+               configuration: _conf_runner)
+
+py2 = find_program('python2')
+tr = meson.current_build_dir()+'/test_runner.py'
+
+foreach _t : _tests
+    _test_prefix = _prefix+'/'+_t
+    _dim = _t.split('/')[0]
+    _name = _t.split('/')[1]
+    test(_t+'.test_runner', py2, args:[tr],
+         workdir: _test_prefix, is_parallel: false, suite: [_dim, _name],
+         timeout: 900)
+endforeach

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -49,9 +49,7 @@ _tests = ['1D/B2_BeG_017',
 
 foreach _t : _tests
     _test_prefix = _prefix+'/'+_t
-    _dim = _t.split('/')[0]
-    _name = _t.split('/')[1]
-   test(_t, geotop, args:[_test_prefix], suite: [_dim, _name],
+   test(_t, geotop, args:[_test_prefix], suite: _t.split('/'),
         timeout: 900)
 endforeach
 
@@ -78,9 +76,7 @@ tr = meson.current_build_dir()+'/test_runner.py'
 
 foreach _t : _tests
     _test_prefix = _prefix+'/'+_t
-    _dim = _t.split('/')[0]
-    _name = _t.split('/')[1]
     test(_t+'.test_runner', py2, args:[tr],
-         workdir: _test_prefix, is_parallel: false, suite: [_dim, _name],
+         workdir: _test_prefix, is_parallel: false, suite: _t.split('/'),
          timeout: 900)
 endforeach

--- a/tests/test_runner.py.in
+++ b/tests/test_runner.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-#
 # @(#)test_runner.py.in
 #
@@ -61,12 +61,12 @@ if pandas:
     warnings.simplefilter(action = "ignore", category = FutureWarning)
 
 # path to the geotop binary
-GEOTOP = "${GEOTOP_PROGRAM_PATH}"
+GEOTOP = "@GEOTOP_PROGRAM_PATH@"
 # geotop compile flag
-METEOIO_ACTUAL_STATUS = "${METEOIOPREFIX}"
+METEOIO_ACTUAL_STATUS = "@METEOIOPREFIX@"
 
 # directory containing this file
-TESTDIR = "${GEOTOP_TEST_DIR}"
+TESTDIR = "@GEOTOP_TEST_DIR@"
 
 # output directories
 OUTPUT_TABS = "output-tabs" 

--- a/utils/astyle.rc
+++ b/utils/astyle.rc
@@ -1,5 +1,5 @@
 
-# astyle 3.0.1 indentation style for geotop
+# astyle 3.1 indentation style for geotop
 
 --style=gnu
 

--- a/utils/indent
+++ b/utils/indent
@@ -34,13 +34,13 @@ if test -z "`which astyle`" ; then
   echo "*** No astyle program found."
   echo "***"
   echo "*** You can download astyle from http://astyle.sourceforge.net/"
-  echo "*** Note that you will need exactly version 3.0.1 (no newer or"
+  echo "*** Note that you will need exactly version 3.1 (no newer or"
   echo "*** older version will yield the correct indentation)."
   exit 1
 fi
 
-if test "`astyle --version 2>&1`" != "Artistic Style Version 3.0.1" ; then
-  echo "*** Found a version of astyle different than the required version 3.0.1."
+if test "`astyle --version 2>&1`" != "Artistic Style Version 3.1" ; then
+  echo "*** Found a version of astyle different than the required version 3.1."
   exit 1
 fi
 

--- a/utils/meson_indent
+++ b/utils/meson_indent
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd "${MESON_SOURCE_ROOT}"
+
+./utils/indent


### PR DESCRIPTION
for fun and learning purposes I've added the meson build system (www.mesonbuild.com). It is fast, user-friendly and uses `ninja` as backend.

meson requires `python3` and `ninja`. It can be called as cmake:
```
$ cd /geotop/top/dir
$ mkdir build_meson
$ cd build_meson
$ meson ..
$ ninja
```

if you have `meteoio` in some non default path you can pass (as you do for cmake)
```
$ meson -Dmeteoio_path=/path/to/your/metoio ..
```
This is not to be intended as replacement (for now..) of CMake but just an experiment.

Just to mention few projects that switched to meson:
- gnome
- systemd
- GStreamer
