### PR TITLE
run test_runner in parallel with meson

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -59,12 +59,18 @@ endforeach
 _comp = find_program('compare.sh', required: false)
 _nd = find_program('numdiff', required: false)
 
+
+# we need to wait that all the previous tests are finished before we
+# can check the output. So we declare the first test_runner with
+# `is_parallel: false` and all the others with `is_parallel: true`
+_p = false
 if(_nd.found())
     foreach _t : _tests
         _test_prefix = _prefix+'/'+_t
         test(_t+'.test_runner', _comp,
-             workdir: _test_prefix, is_parallel: false, suite: _t.split('/'),
-             timeout: 900)
+             workdir: _test_prefix, is_parallel: _p, suite: _t.split('/'),
+             timeout: 90)
+        _p = true
     endforeach
 else
     warning('In order to properly check the output of the tests, please install numdiff')


### PR DESCRIPTION
before this patch 
```
real	0m22.191s
user	0m21.107s
sys	0m0.874s
```


with this patch
```
real	0m11.073s
user	0m30.558s
sys	0m0.933s
```