### PR TITLE
fixing wrong instructions for building getop using meson

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,18 +51,6 @@ make -j4
 mkdir meson-build
 cd meson-build
 ```
-- Check the default values for the options, opening the file meson.build
-in the upper directory or typing:
-```
-meson configure
-```
-
-- If you want to modify some of them, add -Doption=value: for example
-to set the build type to debug type write:
-```
-meson configure -Dbuildtype=debug
-```
-
 - Create the build file:
 ```
 meson
@@ -80,8 +68,20 @@ drwxrwxr-x 4 elisa elisa  4096 giu 15 14:39 src
 drwxrwxr-x 3 elisa elisa  4096 giu 15 14:39 subprojects
 drwxrwxr-x 3 elisa elisa  4096 giu 15 14:39 tests
 ```
+
+- Check the default values for the options, opening the file meson.build
+in the upper directory or typing:
+```
+meson configure
+```
+
+- If you want to modify some of them, add -Doption=value: for example
+to set the build type to debug type write:
+```
+meson configure -Dbuildtype=debug
+```
+
 - Compile: 
 ```
 ninja
-```
 ```


### PR DESCRIPTION
Notice that the instruction for building GEOtop with meson outlined in the readme aren't correct.

When following the instruction the execution of `meson configure` will result in the following error:

```
Meson configurator encountered an error:

ERROR: Directory /src/github.com/geotopmodel/geotop/meson-build does not seem to be a Meson build directory.
``` 

Ran into the problem using these versions of meson `0.47.1` and `0.47.2`.