### PR TITLE
modified logger.h to print nothing to stdout 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 SET( CMAKE_BUILD_TYPE RELEASE CACHE STRING "A variable which controls the type of build" )
 SET( CMAKE_CXX_FLAGS " -std=c++11 " CACHE STRING "")
 SET( CMAKE_CXX_FLAGS_DEBUG " -Wextra -Wall -g -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -O0 " CACHE STRING "" )
-SET( CMAKE_CXX_FLAGS_RELEASE " -Wextra -Wall -O2 -funroll-loops -fstrict-aliasing -Wno-narrowing -Wno-writable-strings -Wno-c++11-narrowing " CACHE STRING "" )
+SET( CMAKE_CXX_FLAGS_RELEASE " -Wextra -Wall -O2 -funroll-loops -fstrict-aliasing -Wno-narrowing -Wno-writable-strings -Wno-c++11-narrowing -DNDEBUG -DMUTE_GEOLOG" CACHE STRING "" )
 SET( CMAKE_CXX_FLAGS_MINSIZEREL " -Wextra -Wall -O2 " CACHE STRING "" )
 
 project(geotop LANGUAGES CXX C)

--- a/meson/compilers/clang/meson.build
+++ b/meson/compilers/clang/meson.build
@@ -1,5 +1,5 @@
 _bt = get_option('buildtype') 
-if _bt == 'debugoptimized' or _bt == 'release'
+if _bt == 'debugoptimized' or _bt == 'release' #or _bt == 'plain'
   add_global_arguments(['-ffp-contract=fast'],
                        language : ['cpp','c'])
 endif

--- a/meson/compilers/intel/meson.build
+++ b/meson/compilers/intel/meson.build
@@ -1,5 +1,5 @@
 _bt = get_option('buildtype') 
-if _bt == 'debugoptimized' or _bt == 'release'
+if _bt == 'debugoptimized' or _bt == 'release' #or _bt == 'plain'
   add_global_arguments('-fp_speculative=safe',
                        language : ['cpp','c'])
 endif

--- a/meson/compilers/meson.build
+++ b/meson/compilers/meson.build
@@ -1,7 +1,8 @@
 # to do: other options
 
 
-_bt = get_option('buildtype') 
+_bt = get_option('buildtype')
+
 if _bt == 'debugoptimized' or _bt == 'release'
   add_global_arguments(['-funroll-loops',
                         '-fstrict-aliasing',
@@ -9,6 +10,15 @@ if _bt == 'debugoptimized' or _bt == 'release'
                         '-DNDEBUG'],
                        language : ['cpp','c'])
 endif
+
+# if _bt == 'plain' 
+#   add_global_arguments(['-funroll-loops',
+#                         '-fstrict-aliasing',
+#                         '-O2',
+#                         '-DNDEBUG',
+# 			'-DMUTE_GEOLOG'],
+#                        language : ['cpp','c'])
+# endif
 
 _supported_compilers = ['clang', 'gcc', 'intel']
 

--- a/meson/compilers/meson.build
+++ b/meson/compilers/meson.build
@@ -7,18 +7,10 @@ if _bt == 'debugoptimized' or _bt == 'release'
   add_global_arguments(['-funroll-loops',
                         '-fstrict-aliasing',
                         '-O2',
-                        '-DNDEBUG'],
+                        '-DNDEBUG',
+                        '-DMUTE_GEOLOG'],
                        language : ['cpp','c'])
 endif
-
-# if _bt == 'plain' 
-#   add_global_arguments(['-funroll-loops',
-#                         '-fstrict-aliasing',
-#                         '-O2',
-#                         '-DNDEBUG',
-# 			'-DMUTE_GEOLOG'],
-#                        language : ['cpp','c'])
-# endif
 
 _supported_compilers = ['clang', 'gcc', 'intel']
 

--- a/readme.md
+++ b/readme.md
@@ -77,14 +77,15 @@ meson configure
 ```
 
 - If you want to modify some of them, add -Doption=value: for example
-  -  set the build type to debug type:
+    -  set the build type to debug type:
 ```
 meson configure -Dbuildtype=debug
 ```
-  - add compiler and linker options (i.e., add ```-pg```)
+    - add compiler and linker options (i.e., add ```-pg```)
 ```
  meson configure -Dcpp_args=-pg -Dcpp_link_args=-pg
- ```
+```
+
 - Compile:
 ```
 ninja

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,27 @@ drwxrwxr-x 3 elisa elisa  4096 giu 15 14:23 tests
 make -j4
 ```
 
+### Testing
+- Know which tests are available:
+```
+ ctest -N
+ ```
+
+- Run a single test (i.e. Mazia):
+```
+ctest -R Mazia
+```
+
+- Run a group of tests (i.e. all 1D tests, using 4 processes):
+```
+ctest -R 1D -j4
+```
+
+- Run all tests
+```
+ctest
+```
+
 ## Meson
 - Create the build directory and go inside it:
 ```
@@ -90,7 +111,7 @@ ninja
 ```
  meson test --list
  ```
- 
+
 - Run a single test (i.e. Mazia):
 ```
 meson test --suite geotop:Mazia

--- a/readme.md
+++ b/readme.md
@@ -78,9 +78,30 @@ meson configure
 
 - If you want to modify some of them, add -Doption=value: for example
     - set the build type to debug type: ``` meson configure -Dbuildtype=debug ```
-    - add compiler and linker options (i.e., add ```-pg```): ``` meson configure -Dcpp_args=-pg -Dcpp_link_args=-pg```
+    - add compiler and linker options (i.e. add ```-pg```): ``` meson configure -Dcpp_args=-pg -Dcpp_link_args=-pg```
 
 - Compile:
 ```
 ninja
+```
+
+### Testing
+- Know which tests are available:
+```
+ meson test --list
+ ```
+ 
+- Run a single test (i.e. Mazia):
+```
+meson test --suite geotop:Mazia
+```
+
+- Run a group of tests (i.e. all 1D tests):
+```
+meson test --suite geotop:1D
+```
+
+- Run all tests
+```
+ninja test
 ```

--- a/readme.md
+++ b/readme.md
@@ -77,14 +77,8 @@ meson configure
 ```
 
 - If you want to modify some of them, add -Doption=value: for example
-    -  set the build type to debug type:
-```
-meson configure -Dbuildtype=debug
-```
-    - add compiler and linker options (i.e., add ```-pg```)
-```
- meson configure -Dcpp_args=-pg -Dcpp_link_args=-pg
-```
+    - set the build type to debug type: ``` meson configure -Dbuildtype=debug ```
+    - add compiler and linker options (i.e., add ```-pg```): ``` meson configure -Dcpp_args=-pg -Dcpp_link_args=-pg```
 
 - Compile:
 ```

--- a/readme.md
+++ b/readme.md
@@ -77,11 +77,11 @@ meson configure
 ```
 
 - If you want to modify some of them, add -Doption=value: for example
- -  set the build type to debug type:
+  -  set the build type to debug type:
 ```
 meson configure -Dbuildtype=debug
 ```
- - add compiler and linker options (i.e., add ```-pg```)
+  - add compiler and linker options (i.e., add ```-pg```)
 ```
  meson configure -Dcpp_args=-pg -Dcpp_link_args=-pg
  ```

--- a/readme.md
+++ b/readme.md
@@ -23,8 +23,8 @@ ccmake ..
 - Press [t] to toggle the advanced mode; several options will appear.
 Select the build type, writing RELEASE or DEBUG after ```CMAKE_BUILD_TYPE```,
 and modify the other flags as you prefer, knowing that a flag like:
-    - *_RELEASE: will be applied only when compiling in RELEASE mode
-    - *_DEBUG: will be applied only when compiling in DEBUG mode.
+    - **RELEASE**: will be applied only when compiling in RELEASE mode
+    - **DEBUG**: will be applied only when compiling in DEBUG mode.
 
 - Press again [c] and [e] to configure; then press [g] to generate and exit.
 Now the current directory will have the following files and folders:
@@ -38,7 +38,6 @@ drwxrwxr-x 5 elisa elisa  4096 giu 15 14:23 CMakeFiles
 -rw-rw-r-- 1 elisa elisa 51860 giu 15 14:23 Makefile
 drwxrwxr-x 3 elisa elisa  4096 giu 15 14:22 src
 drwxrwxr-x 3 elisa elisa  4096 giu 15 14:23 tests
-
 ```
 - Compile (-j4 allows the usage of 4 processes):
 ```
@@ -78,12 +77,15 @@ meson configure
 ```
 
 - If you want to modify some of them, add -Doption=value: for example
-to set the build type to debug type write:
+ -  set the build type to debug type:
 ```
 meson configure -Dbuildtype=debug
 ```
-
-- Compile: 
+ - add compiler and linker options (i.e., add ```-pg```)
+```
+ meson configure -Dcpp_args=-pg -Dcpp_link_args=-pg
+ ```
+- Compile:
 ```
 ninja
 ```

--- a/src/geotop/logger.h
+++ b/src/geotop/logger.h
@@ -13,7 +13,7 @@
 #include <string>
 
 class Logger {
-public:
+ public:
   /**
    * Utility class to add and remove a prefix to a Logger.
    * In the constructor it pushes the string to the Logger.
@@ -85,13 +85,13 @@ public:
    * etc.
    */
   Logger &operator<<(std::ostream &(*basic_manipulator)(std::ostream &)) {
-    /* #ifndef NDEBUG */
+#ifndef NDEBUG
     std::ostringstream os;
     os << basic_manipulator;
     return *this << os.str();
-    /* #else */
-    /*     return *this; */
-    /* #endif */
+#else
+    return *this;
+#endif
   }
 
   /**
@@ -133,7 +133,7 @@ public:
     _file_level = file_level;
   }
 
-private:
+ private:
   /**
    * stack of prefixes
    */
@@ -168,7 +168,7 @@ private:
 extern Logger geolog;
 
 template <typename T> inline Logger &operator<<(Logger &l, const T &t) {
-  /* #ifndef NDEBUG */
+#ifndef NDEBUG 
   std::ostringstream os;
   if (l._at_new_line)
     os << l.prefix();
@@ -180,66 +180,66 @@ template <typename T> inline Logger &operator<<(Logger &l, const T &t) {
     *(l.ofile) << s;
   l._at_new_line = (s == "\n");
   return l;
-/* #else */
-/*   (void)t; */
-/*   return l; */
-/* #endif */
+#else
+  (void)t;
+  return l;
+#endif
 }
 
 class Logger::ScopedPrefix {
-public:
+ public:
   /**
    * Push string @param s to logger @param l
    */
-  ScopedPrefix(const std::string &s, Logger &l) : log{&l} { log->push(s); }
+ ScopedPrefix(const std::string &s, Logger &l) : log{&l} { log->push(s); }
 
   /**
    * Push string @param s to the default logger geolog
    */
-  ScopedPrefix(const std::string &s) : ScopedPrefix{s, geolog} {}
+ ScopedPrefix(const std::string &s) : ScopedPrefix{s, geolog} {}
 
   /**
    * Call log->pop();
    */
   ~ScopedPrefix() { log->pop(); }
 
-private:
+ private:
   Logger *log;
 };
 
 /** helper class to implement all the ScopedLevel classes */
 class ScopedLevel {
-public:
+ public:
   /**
    * Constructor. Needs a function to be called in order set the level to the
    * passed value @param level and then restore it to  its original value.
    * @param logger_set_level
    * @param level
    */
-  ScopedLevel(std::function<void(const unsigned int)> logger_set_level,
-              const unsigned int level, const unsigned int old_level)
-      : set_level{logger_set_level}, _old_level{old_level} {
+ ScopedLevel(std::function<void(const unsigned int)> logger_set_level,
+	     const unsigned int level, const unsigned int old_level)
+   : set_level{logger_set_level}, _old_level{old_level} {
     set_level(level);
   }
 
   /** Destructor: restore the level to the previous value */
   ~ScopedLevel() { set_level(_old_level); }
 
-private:
+ private:
   std::function<void(const unsigned int)> set_level;
   const unsigned int _old_level;
 };
 
 class Logger::ScopedConsoleLevel {
-public:
+ public:
   /**
    * set the console level of @param l to @param level
    */
-  ScopedConsoleLevel(const unsigned int level, Logger &l = geolog)
-      : log{&l}, console{[this](const unsigned int ll) {
-                           log->set_console_level(ll);
-                         },
-                         level, l.console_level()} {}
+ ScopedConsoleLevel(const unsigned int level, Logger &l = geolog)
+   : log{&l}, console{[this](const unsigned int ll) {
+      log->set_console_level(ll);
+    },
+		  level, l.console_level()} {}
 
   /**
    * restore the console level of the logger pointed to by @param log to it's
@@ -248,7 +248,7 @@ public:
    */
   ~ScopedConsoleLevel() = default;
 
-private:
+ private:
   /** pointer to the logger */
   Logger *log;
 
@@ -257,14 +257,14 @@ private:
 };
 
 class Logger::ScopedFileLevel {
-public:
+ public:
   /**
    * set the file level of @param l to @param level
    */
-  ScopedFileLevel(const unsigned int level, Logger &l = geolog)
-      : log{&l}, file{
-                     [this](const unsigned int ll) { log->set_file_level(ll); },
-                     level, l.file_level()} {}
+ ScopedFileLevel(const unsigned int level, Logger &l = geolog)
+   : log{&l}, file{
+    [this](const unsigned int ll) { log->set_file_level(ll); },
+      level, l.file_level()} {}
 
   /**
    * restore the file level of the logger pointed to by @param log to it's
@@ -273,7 +273,7 @@ public:
    */
   ~ScopedFileLevel() = default;
 
-private:
+ private:
   /** pointer to the logger */
   Logger *log;
 
@@ -282,16 +282,16 @@ private:
 };
 
 class Logger::ScopedLevels {
-public:
-  ScopedLevels(const unsigned int cl, const unsigned fl, Logger &l = geolog)
-      : _fl{fl, l}, _cl{cl, l} {}
+ public:
+ ScopedLevels(const unsigned int cl, const unsigned fl, Logger &l = geolog)
+   : _fl{fl, l}, _cl{cl, l} {}
 
-  ScopedLevels(const unsigned int cl, Logger &l = geolog)
-      : _fl{cl, l}, _cl{cl, l} {}
+ ScopedLevels(const unsigned int cl, Logger &l = geolog)
+   : _fl{cl, l}, _cl{cl, l} {}
 
   ~ScopedLevels() = default;
 
-private:
+ private:
   ScopedFileLevel _fl;
   ScopedConsoleLevel _cl;
 };

--- a/src/geotop/logger.h
+++ b/src/geotop/logger.h
@@ -85,14 +85,13 @@ class Logger {
    * etc.
    */
   Logger &operator<<(std::ostream &(*basic_manipulator)(std::ostream &)) {
-# ifndef MUTE_GEOTOP
+#ifdef MUTE_GEOLOG
+    return *this;
+#else
     std::ostringstream os;
     os << basic_manipulator;
     return *this << os.str();
-#else
-    return *this;
 #endif
-    
   }
 
   /**
@@ -169,7 +168,10 @@ class Logger {
 extern Logger geolog;
 
 template <typename T> inline Logger &operator<<(Logger &l, const T &t) {
-#ifndef MUTE_GEOTOP
+#ifdef MUTE_GEOLOG
+   (void)t;
+  return l;
+#else
   std::ostringstream os;
   if (l._at_new_line)
     os << l.prefix();
@@ -180,9 +182,6 @@ template <typename T> inline Logger &operator<<(Logger &l, const T &t) {
   if (l.ofile && (l.prefix_depth_level() <= l.file_level()))
     *(l.ofile) << s;
   l._at_new_line = (s == "\n");
-  return l;
-#else
-  (void)t;
   return l;
 #endif
 }

--- a/src/geotop/logger.h
+++ b/src/geotop/logger.h
@@ -85,9 +85,13 @@ public:
    * etc.
    */
   Logger &operator<<(std::ostream &(*basic_manipulator)(std::ostream &)) {
+    /* #ifndef NDEBUG */
     std::ostringstream os;
     os << basic_manipulator;
     return *this << os.str();
+    /* #else */
+    /*     return *this; */
+    /* #endif */
   }
 
   /**
@@ -164,6 +168,7 @@ private:
 extern Logger geolog;
 
 template <typename T> inline Logger &operator<<(Logger &l, const T &t) {
+  /* #ifndef NDEBUG */
   std::ostringstream os;
   if (l._at_new_line)
     os << l.prefix();
@@ -175,6 +180,10 @@ template <typename T> inline Logger &operator<<(Logger &l, const T &t) {
     *(l.ofile) << s;
   l._at_new_line = (s == "\n");
   return l;
+/* #else */
+/*   (void)t; */
+/*   return l; */
+/* #endif */
 }
 
 class Logger::ScopedPrefix {

--- a/src/geotop/logger.h
+++ b/src/geotop/logger.h
@@ -85,13 +85,14 @@ class Logger {
    * etc.
    */
   Logger &operator<<(std::ostream &(*basic_manipulator)(std::ostream &)) {
-#ifndef NDEBUG
+# ifndef MUTE_GEOTOP
     std::ostringstream os;
     os << basic_manipulator;
     return *this << os.str();
 #else
     return *this;
 #endif
+    
   }
 
   /**
@@ -168,7 +169,7 @@ class Logger {
 extern Logger geolog;
 
 template <typename T> inline Logger &operator<<(Logger &l, const T &t) {
-#ifndef NDEBUG 
+#ifndef MUTE_GEOTOP
   std::ostringstream os;
   if (l._at_new_line)
     os << l.prefix();
@@ -296,6 +297,10 @@ class Logger::ScopedLevels {
   ScopedConsoleLevel _cl;
 };
 
-#define GEOLOG_PREFIX(string) Logger::ScopedPrefix __geolog_prefix__{string};
+#ifndef NDEBUG
+# define GEOLOG_PREFIX(string) Logger::ScopedPrefix __geolog_prefix__{string};
+#else
+# define GEOLOG_PREFIX(dummy)
+#endif
 
 #endif // GEOTOP_LOGGER_H

--- a/tests/3D/Muntatschini_ref_005/io_it.ini
+++ b/tests/3D/Muntatschini_ref_005/io_it.ini
@@ -1,0 +1,116 @@
+[General]
+PLUGINPATH	= /usr/local/lib/meteoio/plugins
+BUFF_CHUNK_SIZE = 30
+BUFF_BEFORE	= 1.5
+
+[Input]
+[Input]
+TIME_ZONE	= +1
+COORDSYS	= UTM
+COORDPARAM	= 32N
+#reading ARC dem
+DEM		= ARC
+
+DEMFILE  	=./INmaps20/dem.asc
+GRID2D		= ARC
+GRID2DPATH = .
+
+#GEOtop traditional inputs -> GEOTOP plugin
+METEO = GEOTOP
+METEOPATH =./meteo
+METEOPREFIX = meteo
+METAFILE = ./geotop.inpts
+ 
+[Output]
+TIME_ZONE 	= +1
+COORDSYS	= UTM
+COORDPARAM	= 32N
+
+GRID2DPATH = ./meteoio_output
+GRID2D        = ARC
+
+#GEOTOP output
+METEO          = GEOTOP
+METEOPATH      = ./meteoio_output
+METEOSEQ       = WindDir Iprec Swglob AirT RH WindSp   
+
+[Filters]
+TA::filter1	= min_max
+TA::arg1    = 223 323 ; for celsius add an offset of 273.15
+
+RH::filter1	= min_max
+RH::arg1 	= 0.1 1.15
+RH::filter2	= min_max
+RH::arg2	= soft 0.05 1.0
+
+PSUM::filter1	= min_max
+PSUM::arg1	=  -1. 50.
+PSUM::filter2	= min_max
+PSUM::arg2	=  soft 0 45
+
+ISWR::filter1	= min_max
+ISWR::arg1	= -10. 1500.
+ISWR::filter2	= min
+ISWR::arg2	= soft 0 1400
+
+RSWR::filter1	= min_max
+RSWR::arg1 	= -10 1500
+RSWR::filter2	= min
+RSWR::arg2	= soft 0 1400
+
+#for TA between 240 and 320 K
+ILWR::filter1	= min_max
+ILWR::arg1	= 188 600
+ILWR::filter2	= min_max
+ILWR::arg2	= soft 200 400
+
+#we need to consider time with no snow -> TSS>0
+#min(TSS) in db since 1998: -50C
+TSS::filter1	= min_max
+TSS::arg1	= 200 320
+#idem
+TSG::filter1	= min_max
+TSG::arg1	= 200 320
+HS::filter1	= min
+HS::arg1	= soft 0.0
+HS::filter2	= rate
+HS::arg2	= 5.55e-5 ;0.20 m/h
+
+VW::filter1 = min_max
+VW::arg1 = -2 70
+VW::filter2 = min_max
+VW::arg2 = soft 0.0 50.0
+
+[Interpolations1D]
+#resampling window is 24 hours(= 86400 seconds) 
+WINDOW_SIZE	= 86400  ;186400   
+TA::resample = linear
+TA::linear = 3600 extrapolate
+
+RH::resample = linear
+RH::linear = 3600 extrapolate
+
+VW::resample = nearest
+VW::nearest = extrapolate
+
+;PSUM::resample = accumulate
+;PSUM::accumulate = 900
+PSUM::resample = linear
+PSUM::linear = 3600 extrapolate
+
+
+[Interpolations2D]
+TA::algorithms	= IDW_LAPSE ;USER LIDW_LAPSE IDW_LAPSE CST_LAPSE
+TA::cst_lapse = -0.0065 soft
+TA::idw_lapse   = -0.0065 soft
+TA::user	= ./test
+RH::algorithms	= IDW_LAPSE CST;RH
+PSUM::algorithms	=IDW ; IDW IDW_LAPSE CST_LAPSE CST
+RSWR::algorithms = IDW CST;for TawCloud
+RSWR::cst = 0.5 soft
+DW::algorithms = IDW CST
+DW:cst = 90 soft
+VW::algorithms = CST
+VW::wind_curv = 0. soft
+VW:cst = 0.1 soft
+P::algorithms	= STD_PRESS

--- a/tests/unit_tests/logger/logger_01.cc
+++ b/tests/unit_tests/logger/logger_01.cc
@@ -30,11 +30,7 @@ TEST(ScopedPrefix, basic_test) {
   
   {
     Logger::ScopedPrefix p{__func__}; // let us use the function name
-#ifndef NDEBUG
     EXPECT_EQ(geolog.prefix(), "geotop:TestBody:");
-#else
-    EXPECT_EQ(geolog.prefix(), "geotop:");
-#endif
   }
   
   // do the same using the macro

--- a/tests/unit_tests/logger/logger_01.cc
+++ b/tests/unit_tests/logger/logger_01.cc
@@ -44,6 +44,7 @@ TEST(Logger, output_operator){
 	 << "nuova riga"  << " continua" << std::endl
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
+  
 #ifndef NDEBUG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
 #else
@@ -60,6 +61,7 @@ TEST(Logger, file_stream){
 	 << "nuova riga"  << " continua" << std::endl
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
+  
 #ifndef NDEBUG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
   EXPECT_EQ(testing::internal::GetCapturedStderr(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
@@ -80,6 +82,7 @@ TEST(Logger, detach_file_stream){
 	 << "nuova riga"  << " continua" << std::endl
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
+  
 #ifndef NDEBUG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
 #else
@@ -95,6 +98,7 @@ TEST(Logger, iomanip_functions){
   os << std::setw(10) << 7; 
   geolog << os.str() << std::endl;
   geolog << 1234567890 << std::endl;
+  
 #ifndef NDEBUG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:         7\ngeotop:1234567890\n");
 #else
@@ -114,6 +118,7 @@ TEST(Logger, for_loop){
     geolog << std::endl;
   }
   geolog << "cycle ended" <<std::endl;
+  
 #ifndef NDEBUG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:entering \ngeotop:for:vector elements: 1 2 3 \ngeotop:cycle ended\n");
 #else

--- a/tests/unit_tests/logger/logger_01.cc
+++ b/tests/unit_tests/logger/logger_01.cc
@@ -44,7 +44,11 @@ TEST(Logger, output_operator){
 	 << "nuova riga"  << " continua" << std::endl
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
+#ifndef NDEBUG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#endif
 }
 
 TEST(Logger, file_stream){
@@ -56,8 +60,13 @@ TEST(Logger, file_stream){
 	 << "nuova riga"  << " continua" << std::endl
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
+#ifndef NDEBUG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
   EXPECT_EQ(testing::internal::GetCapturedStderr(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+  EXPECT_EQ(testing::internal::GetCapturedStderr(), "");
+#endif
 }
 
 
@@ -71,7 +80,11 @@ TEST(Logger, detach_file_stream){
 	 << "nuova riga"  << " continua" << std::endl
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
+#ifndef NDEBUG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#endif 
   EXPECT_EQ(testing::internal::GetCapturedStderr(), "");
 }
 
@@ -82,7 +95,11 @@ TEST(Logger, iomanip_functions){
   os << std::setw(10) << 7; 
   geolog << os.str() << std::endl;
   geolog << 1234567890 << std::endl;
+#ifndef NDEBUG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:         7\ngeotop:1234567890\n");
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#endif   
 }
 
 TEST(Logger, for_loop){
@@ -97,7 +114,11 @@ TEST(Logger, for_loop){
     geolog << std::endl;
   }
   geolog << "cycle ended" <<std::endl;
+#ifndef NDEBUG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:entering \ngeotop:for:vector elements: 1 2 3 \ngeotop:cycle ended\n");
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#endif   
 }
 
 

--- a/tests/unit_tests/logger/logger_01.cc
+++ b/tests/unit_tests/logger/logger_01.cc
@@ -20,20 +20,33 @@ TEST(Logger, geolog) {
 
 TEST(ScopedPrefix, basic_test) {
   Logger l{};
+  
   {
     Logger::ScopedPrefix p{"alberto",l};
     EXPECT_EQ(l.prefix(), "geotop:alberto:");
   }
+
   EXPECT_EQ(l.prefix(), "geotop:");
+  
   {
-    Logger::ScopedPrefix p{__func__}; // let us use the function name 
+    Logger::ScopedPrefix p{__func__}; // let us use the function name
+#ifndef NDEBUG
     EXPECT_EQ(geolog.prefix(), "geotop:TestBody:");
+#else
+    EXPECT_EQ(geolog.prefix(), "geotop:");
+#endif
   }
+  
   // do the same using the macro
   {
-    GEOLOG_PREFIX(__func__); // let us use the function name 
+    GEOLOG_PREFIX(__func__); // let us use the function name
+#ifndef NDEBUG
     EXPECT_EQ(geolog.prefix(), "geotop:TestBody:");
+#else
+    EXPECT_EQ(geolog.prefix(), "geotop:");
+#endif
   }
+  
   l.pop();
   EXPECT_EQ(l.prefix(), "");
 }
@@ -45,7 +58,7 @@ TEST(Logger, output_operator){
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
   
-#ifndef NDEBUG   
+#ifndef MUTE_GEOLOG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
 #else
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
@@ -62,7 +75,7 @@ TEST(Logger, file_stream){
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
   
-#ifndef NDEBUG   
+#ifndef MUTE_GEOLOG     
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
   EXPECT_EQ(testing::internal::GetCapturedStderr(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
 #else
@@ -83,7 +96,7 @@ TEST(Logger, detach_file_stream){
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
   
-#ifndef NDEBUG   
+#ifndef MUTE_GEOLOG    
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
 #else
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
@@ -99,7 +112,7 @@ TEST(Logger, iomanip_functions){
   geolog << os.str() << std::endl;
   geolog << 1234567890 << std::endl;
   
-#ifndef NDEBUG   
+#ifndef MUTE_GEOLOG   
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:         7\ngeotop:1234567890\n");
 #else
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
@@ -119,7 +132,7 @@ TEST(Logger, for_loop){
   }
   geolog << "cycle ended" <<std::endl;
   
-#ifndef NDEBUG   
+#ifndef MUTE_GEOLOG     
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:entering \ngeotop:for:vector elements: 1 2 3 \ngeotop:cycle ended\n");
 #else
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");

--- a/tests/unit_tests/logger/logger_01.cc
+++ b/tests/unit_tests/logger/logger_01.cc
@@ -54,10 +54,10 @@ TEST(Logger, output_operator){
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
   
-#ifndef MUTE_GEOLOG   
-  EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
+#ifdef MUTE_GEOLOG
+    EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
 #else
-  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+    EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
 #endif
 }
 
@@ -71,12 +71,12 @@ TEST(Logger, file_stream){
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
   
-#ifndef MUTE_GEOLOG     
-  EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
-  EXPECT_EQ(testing::internal::GetCapturedStderr(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
-#else
+#ifdef MUTE_GEOLOG
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
   EXPECT_EQ(testing::internal::GetCapturedStderr(), "");
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
+  EXPECT_EQ(testing::internal::GetCapturedStderr(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
 #endif
 }
 
@@ -92,11 +92,12 @@ TEST(Logger, detach_file_stream){
 	 << " queste righe \n sono molto \n piu' complicate" << std::endl
 	 <<"con " << std::flush << "jacopo" << std::endl;
   
-#ifndef MUTE_GEOLOG    
-  EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
-#else
+#ifdef MUTE_GEOLOG
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
-#endif 
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:ciao alberto\ngeotop:nuova riga continua\ngeotop: queste righe \n sono molto \n piu' complicate\ngeotop:con jacopo\n");
+#endif
+  
   EXPECT_EQ(testing::internal::GetCapturedStderr(), "");
 }
 
@@ -108,10 +109,10 @@ TEST(Logger, iomanip_functions){
   geolog << os.str() << std::endl;
   geolog << 1234567890 << std::endl;
   
-#ifndef MUTE_GEOLOG   
-  EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:         7\ngeotop:1234567890\n");
-#else
+#ifdef MUTE_GEOLOG
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:         7\ngeotop:1234567890\n");
 #endif   
 }
 
@@ -128,10 +129,10 @@ TEST(Logger, for_loop){
   }
   geolog << "cycle ended" <<std::endl;
   
-#ifndef MUTE_GEOLOG     
-  EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:entering \ngeotop:for:vector elements: 1 2 3 \ngeotop:cycle ended\n");
-#else
+#ifdef MUTE_GEOLOG
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:entering \ngeotop:for:vector elements: 1 2 3 \ngeotop:cycle ended\n");
 #endif   
 }
 

--- a/tests/unit_tests/logger/logger_02.cc
+++ b/tests/unit_tests/logger/logger_02.cc
@@ -58,7 +58,7 @@ TEST(ScopedPrefix, console_depth_level_default) {
   }
   l << "back to first" << std::endl;
   
-#ifndef NDEBUG
+#ifndef MUTE_GEOLOG
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:first level\ngeotop:second:second level\ngeotop:second:third:third level\ngeotop:second:back to second\ngeotop:back to first\n");
 #else
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
@@ -105,7 +105,7 @@ TEST(ScopedPrefix, console_depth_level_1) {
   }
   l << "back to first" << std::endl;
   
-#ifndef NDEBUG
+#ifndef MUTE_GEOLOG
   EXPECT_EQ("geotop:first level\ngeotop:back to first\n", testing::internal::GetCapturedStdout());
   #else
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
@@ -130,7 +130,7 @@ TEST(ScopedPrefix, console_depth_level_2) {
   }
   l << "back to first" << std::endl;
   
-#ifndef NDEBUG
+#ifndef MUTE_GEOLOG
   EXPECT_EQ("geotop:first level\ngeotop:second:second level\ngeotop:second:back to second\ngeotop:back to first\n",
 	    testing::internal::GetCapturedStdout());
 #else
@@ -157,7 +157,7 @@ TEST(ScopedPrefix, console_depth_level_changed) {
   }
   l << "nor this" << std::endl;
   
-#ifndef NDEBUG
+#ifndef MUTE_GEOLOG
   EXPECT_EQ("geotop:first level\ngeotop:second:second level\ngeotop:second:third:third level\n", testing::internal::GetCapturedStdout());
   #else
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
@@ -185,9 +185,10 @@ TEST(ScopedPrefix, console_and_file_levels) {
   }
   l << "this should appear on screen and in file again" << std::endl;
 
-  #ifndef NDEBUG
+  #ifndef MUTE_GEOLOG
   EXPECT_EQ("geotop:this should appear on screen and in file\ngeotop:this should appear on screen and in file again\n", testing::internal::GetCapturedStdout());
-  EXPECT_EQ("geotop:this should appear on screen and in file\ngeotop:second:this is only in file\ngeotop:second:this is only in file again\ngeotop:this should appear on screen and in file again\n", testing::internal::GetCapturedStderr());
+  EXPECT_EQ("geotop:this should appear on screen and in file\ngeotop:second:this is only in file\ngeotop:second:this is only in file again\ngeotop:this should appear on screen and in file again\n",
+	    testing::internal::GetCapturedStderr());
 #else
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
   EXPECT_EQ(testing::internal::GetCapturedStderr(), "");

--- a/tests/unit_tests/logger/logger_02.cc
+++ b/tests/unit_tests/logger/logger_02.cc
@@ -58,10 +58,10 @@ TEST(ScopedPrefix, console_depth_level_default) {
   }
   l << "back to first" << std::endl;
   
-#ifndef MUTE_GEOLOG
-  EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:first level\ngeotop:second:second level\ngeotop:second:third:third level\ngeotop:second:back to second\ngeotop:back to first\n");
-#else
+#ifdef MUTE_GEOLOG
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:first level\ngeotop:second:second level\ngeotop:second:third:third level\ngeotop:second:back to second\ngeotop:back to first\n");
 #endif
   
 }
@@ -105,10 +105,10 @@ TEST(ScopedPrefix, console_depth_level_1) {
   }
   l << "back to first" << std::endl;
   
-#ifndef MUTE_GEOLOG
-  EXPECT_EQ("geotop:first level\ngeotop:back to first\n", testing::internal::GetCapturedStdout());
-  #else
+#ifdef MUTE_GEOLOG
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#else
+  EXPECT_EQ("geotop:first level\ngeotop:back to first\n", testing::internal::GetCapturedStdout());
 #endif
 }
 
@@ -130,11 +130,11 @@ TEST(ScopedPrefix, console_depth_level_2) {
   }
   l << "back to first" << std::endl;
   
-#ifndef MUTE_GEOLOG
-  EXPECT_EQ("geotop:first level\ngeotop:second:second level\ngeotop:second:back to second\ngeotop:back to first\n",
-	    testing::internal::GetCapturedStdout());
+#ifdef MUTE_GEOLOG
+    EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
 #else
-  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+    EXPECT_EQ("geotop:first level\ngeotop:second:second level\ngeotop:second:back to second\ngeotop:back to first\n",
+	      testing::internal::GetCapturedStdout());
 #endif
 }
 
@@ -157,10 +157,10 @@ TEST(ScopedPrefix, console_depth_level_changed) {
   }
   l << "nor this" << std::endl;
   
-#ifndef MUTE_GEOLOG
-  EXPECT_EQ("geotop:first level\ngeotop:second:second level\ngeotop:second:third:third level\n", testing::internal::GetCapturedStdout());
-  #else
-  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#ifdef MUTE_GEOLOG
+    EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#else
+    EXPECT_EQ("geotop:first level\ngeotop:second:second level\ngeotop:second:third:third level\n", testing::internal::GetCapturedStdout());
 #endif
 }
 
@@ -185,13 +185,13 @@ TEST(ScopedPrefix, console_and_file_levels) {
   }
   l << "this should appear on screen and in file again" << std::endl;
 
-  #ifndef MUTE_GEOLOG
-  EXPECT_EQ("geotop:this should appear on screen and in file\ngeotop:this should appear on screen and in file again\n", testing::internal::GetCapturedStdout());
-  EXPECT_EQ("geotop:this should appear on screen and in file\ngeotop:second:this is only in file\ngeotop:second:this is only in file again\ngeotop:this should appear on screen and in file again\n",
-	    testing::internal::GetCapturedStderr());
-#else
+#ifdef MUTE_GEOLOG
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
   EXPECT_EQ(testing::internal::GetCapturedStderr(), "");
+#else
+   EXPECT_EQ("geotop:this should appear on screen and in file\ngeotop:this should appear on screen and in file again\n", testing::internal::GetCapturedStdout());
+  EXPECT_EQ("geotop:this should appear on screen and in file\ngeotop:second:this is only in file\ngeotop:second:this is only in file again\ngeotop:this should appear on screen and in file again\n",
+	    testing::internal::GetCapturedStderr());
 #endif
 }
 

--- a/tests/unit_tests/logger/logger_02.cc
+++ b/tests/unit_tests/logger/logger_02.cc
@@ -57,6 +57,7 @@ TEST(ScopedPrefix, console_depth_level_default) {
     l << "back to second" << std::endl;
   }
   l << "back to first" << std::endl;
+  
 #ifndef NDEBUG
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:first level\ngeotop:second:second level\ngeotop:second:third:third level\ngeotop:second:back to second\ngeotop:back to first\n");
 #else
@@ -103,6 +104,7 @@ TEST(ScopedPrefix, console_depth_level_1) {
     l << "nor this one" << std::endl;
   }
   l << "back to first" << std::endl;
+  
 #ifndef NDEBUG
   EXPECT_EQ("geotop:first level\ngeotop:back to first\n", testing::internal::GetCapturedStdout());
   #else
@@ -127,6 +129,7 @@ TEST(ScopedPrefix, console_depth_level_2) {
     l << "back to second" << std::endl;
   }
   l << "back to first" << std::endl;
+  
 #ifndef NDEBUG
   EXPECT_EQ("geotop:first level\ngeotop:second:second level\ngeotop:second:back to second\ngeotop:back to first\n",
 	    testing::internal::GetCapturedStdout());
@@ -153,6 +156,7 @@ TEST(ScopedPrefix, console_depth_level_changed) {
     l << "you should never read this" << std::endl;
   }
   l << "nor this" << std::endl;
+  
 #ifndef NDEBUG
   EXPECT_EQ("geotop:first level\ngeotop:second:second level\ngeotop:second:third:third level\n", testing::internal::GetCapturedStdout());
   #else

--- a/tests/unit_tests/logger/logger_02.cc
+++ b/tests/unit_tests/logger/logger_02.cc
@@ -57,7 +57,12 @@ TEST(ScopedPrefix, console_depth_level_default) {
     l << "back to second" << std::endl;
   }
   l << "back to first" << std::endl;
+#ifndef NDEBUG
   EXPECT_EQ(testing::internal::GetCapturedStdout(), "geotop:first level\ngeotop:second:second level\ngeotop:second:third:third level\ngeotop:second:back to second\ngeotop:back to first\n");
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#endif
+  
 }
 
 
@@ -98,7 +103,11 @@ TEST(ScopedPrefix, console_depth_level_1) {
     l << "nor this one" << std::endl;
   }
   l << "back to first" << std::endl;
+#ifndef NDEBUG
   EXPECT_EQ("geotop:first level\ngeotop:back to first\n", testing::internal::GetCapturedStdout());
+  #else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#endif
 }
 
 TEST(ScopedPrefix, console_depth_level_2) {
@@ -118,8 +127,12 @@ TEST(ScopedPrefix, console_depth_level_2) {
     l << "back to second" << std::endl;
   }
   l << "back to first" << std::endl;
+#ifndef NDEBUG
   EXPECT_EQ("geotop:first level\ngeotop:second:second level\ngeotop:second:back to second\ngeotop:back to first\n",
 	    testing::internal::GetCapturedStdout());
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#endif
 }
 
 
@@ -140,7 +153,11 @@ TEST(ScopedPrefix, console_depth_level_changed) {
     l << "you should never read this" << std::endl;
   }
   l << "nor this" << std::endl;
+#ifndef NDEBUG
   EXPECT_EQ("geotop:first level\ngeotop:second:second level\ngeotop:second:third:third level\n", testing::internal::GetCapturedStdout());
+  #else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+#endif
 }
 
 
@@ -164,7 +181,12 @@ TEST(ScopedPrefix, console_and_file_levels) {
   }
   l << "this should appear on screen and in file again" << std::endl;
 
+  #ifndef NDEBUG
   EXPECT_EQ("geotop:this should appear on screen and in file\ngeotop:this should appear on screen and in file again\n", testing::internal::GetCapturedStdout());
   EXPECT_EQ("geotop:this should appear on screen and in file\ngeotop:second:this is only in file\ngeotop:second:this is only in file again\ngeotop:this should appear on screen and in file again\n", testing::internal::GetCapturedStderr());
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStdout(), "");
+  EXPECT_EQ(testing::internal::GetCapturedStderr(), "");
+#endif
 }
 

--- a/tests/unit_tests/logger/logger_03.cc
+++ b/tests/unit_tests/logger/logger_03.cc
@@ -18,7 +18,7 @@ TEST(Logger, ScopedConsoleLevel) {
   }
   l << "this should not appear" << std::endl;
   
-#ifndef NDEBUG
+#ifndef MUTE_GEOLOG
   EXPECT_EQ("geotop:second:third:only this should be printed\n",testing::internal::GetCapturedStdout());
 #else
   EXPECT_EQ("", testing::internal::GetCapturedStdout());
@@ -44,7 +44,7 @@ TEST(Logger, ScopedFileLevel) {
   }
   l << "this should not appear" << std::endl;
   
-#ifndef NDEBUG  
+#ifndef MUTE_GEOLOG  
   EXPECT_EQ("geotop:second:third:only this should be printed\n",testing::internal::GetCapturedStderr());
 #else
   EXPECT_EQ("", testing::internal::GetCapturedStderr());
@@ -92,7 +92,7 @@ TEST(Logger, ScopedLevels_mixed_01){
   }
   log << "this should appear on stdout" << std::endl;
 
-#ifndef NDEBUG  
+#ifndef MUTE_GEOLOG  
   EXPECT_EQ("geotop:this should appear on stdout\ngeotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout\ngeotop:this should appear on stdout\n", testing::internal::GetCapturedStdout());
 #else
   EXPECT_EQ("", testing::internal::GetCapturedStdout());
@@ -121,7 +121,7 @@ TEST(Logger, ScopedLevels_mixed_02){
   }
   log << "this should appear on stdout and stderr" << std::endl;
 
-#ifndef NDEBUG  
+#ifndef MUTE_GEOLOG  
   EXPECT_EQ("geotop:this should appear on stdout and stderr\ngeotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout\ngeotop:this should appear on stdout and stderr\n", testing::internal::GetCapturedStdout());
   EXPECT_EQ("geotop:this should appear on stdout and stderr\ngeotop:this should appear on stdout and stderr\n", testing::internal::GetCapturedStderr());
 #else
@@ -152,7 +152,7 @@ TEST(ScopedLevels, ScopedLevels_mixed_03){
   }
   log << "this should not appear" << std::endl;
 
-#ifndef NDEBUG  
+#ifndef MUTE_GEOLOG  
   EXPECT_EQ("geotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout again\n", testing::internal::GetCapturedStdout());
   EXPECT_EQ("geotop:second:third:this should appear on stderr\n", testing::internal::GetCapturedStderr());
 #else
@@ -182,7 +182,7 @@ TEST(ScopedLevels, mixed_geolog){
   }
   geolog << "this should not appear" << std::endl;
   
-#ifndef NDEBUG  
+#ifndef MUTE_GEOLOG  
   EXPECT_EQ("geotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout again\n", testing::internal::GetCapturedStdout());
   EXPECT_EQ("geotop:second:third:this should appear on stderr\n", testing::internal::GetCapturedStderr());
 #else

--- a/tests/unit_tests/logger/logger_03.cc
+++ b/tests/unit_tests/logger/logger_03.cc
@@ -1,8 +1,6 @@
 #include<gtest/gtest.h>
 #include <logger.h>
 
-
-
 TEST(Logger, ScopedConsoleLevel) {
   testing::internal::CaptureStdout();
   Logger l{};
@@ -19,7 +17,12 @@ TEST(Logger, ScopedConsoleLevel) {
     l << "this should not appear" << std::endl;
   }
   l << "this should not appear" << std::endl;
+  
+#ifndef NDEBUG
   EXPECT_EQ("geotop:second:third:only this should be printed\n",testing::internal::GetCapturedStdout());
+#else
+  EXPECT_EQ("", testing::internal::GetCapturedStdout());
+#endif
 }
 
 TEST(Logger, ScopedFileLevel) {
@@ -40,7 +43,12 @@ TEST(Logger, ScopedFileLevel) {
     l << "this should not appear" << std::endl;
   }
   l << "this should not appear" << std::endl;
+  
+#ifndef NDEBUG  
   EXPECT_EQ("geotop:second:third:only this should be printed\n",testing::internal::GetCapturedStderr());
+#else
+  EXPECT_EQ("", testing::internal::GetCapturedStderr());
+#endif
 }
 
 TEST(Logger, ScopedLevels){
@@ -84,7 +92,11 @@ TEST(Logger, ScopedLevels_mixed_01){
   }
   log << "this should appear on stdout" << std::endl;
 
+#ifndef NDEBUG  
   EXPECT_EQ("geotop:this should appear on stdout\ngeotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout\ngeotop:this should appear on stdout\n", testing::internal::GetCapturedStdout());
+#else
+  EXPECT_EQ("", testing::internal::GetCapturedStdout());
+#endif
   EXPECT_EQ("", testing::internal::GetCapturedStderr());
   
 }
@@ -109,9 +121,13 @@ TEST(Logger, ScopedLevels_mixed_02){
   }
   log << "this should appear on stdout and stderr" << std::endl;
 
+#ifndef NDEBUG  
   EXPECT_EQ("geotop:this should appear on stdout and stderr\ngeotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout\ngeotop:this should appear on stdout and stderr\n", testing::internal::GetCapturedStdout());
   EXPECT_EQ("geotop:this should appear on stdout and stderr\ngeotop:this should appear on stdout and stderr\n", testing::internal::GetCapturedStderr());
-  
+#else
+  EXPECT_EQ("", testing::internal::GetCapturedStdout());
+  EXPECT_EQ("", testing::internal::GetCapturedStderr());
+#endif
 }
 
 
@@ -136,8 +152,13 @@ TEST(ScopedLevels, ScopedLevels_mixed_03){
   }
   log << "this should not appear" << std::endl;
 
+#ifndef NDEBUG  
   EXPECT_EQ("geotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout again\n", testing::internal::GetCapturedStdout());
   EXPECT_EQ("geotop:second:third:this should appear on stderr\n", testing::internal::GetCapturedStderr());
+#else
+  EXPECT_EQ("", testing::internal::GetCapturedStdout());
+  EXPECT_EQ("", testing::internal::GetCapturedStderr());
+#endif
 }
 
 
@@ -160,7 +181,12 @@ TEST(ScopedLevels, mixed_geolog){
     geolog << "this should appear on stdout again" << std::endl;
   }
   geolog << "this should not appear" << std::endl;
-
+  
+#ifndef NDEBUG  
   EXPECT_EQ("geotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout again\n", testing::internal::GetCapturedStdout());
   EXPECT_EQ("geotop:second:third:this should appear on stderr\n", testing::internal::GetCapturedStderr());
+#else
+  EXPECT_EQ("", testing::internal::GetCapturedStdout());
+  EXPECT_EQ("", testing::internal::GetCapturedStderr());
+#endif
 }

--- a/tests/unit_tests/logger/logger_03.cc
+++ b/tests/unit_tests/logger/logger_03.cc
@@ -18,10 +18,10 @@ TEST(Logger, ScopedConsoleLevel) {
   }
   l << "this should not appear" << std::endl;
   
-#ifndef MUTE_GEOLOG
-  EXPECT_EQ("geotop:second:third:only this should be printed\n",testing::internal::GetCapturedStdout());
+#ifdef MUTE_GEOLOG
+    EXPECT_EQ("", testing::internal::GetCapturedStdout());
 #else
-  EXPECT_EQ("", testing::internal::GetCapturedStdout());
+    EXPECT_EQ("geotop:second:third:only this should be printed\n",testing::internal::GetCapturedStdout());
 #endif
 }
 
@@ -44,10 +44,10 @@ TEST(Logger, ScopedFileLevel) {
   }
   l << "this should not appear" << std::endl;
   
-#ifndef MUTE_GEOLOG  
-  EXPECT_EQ("geotop:second:third:only this should be printed\n",testing::internal::GetCapturedStderr());
-#else
+#ifdef MUTE_GEOLOG
   EXPECT_EQ("", testing::internal::GetCapturedStderr());
+#else
+  EXPECT_EQ("geotop:second:third:only this should be printed\n",testing::internal::GetCapturedStderr());
 #endif
 }
 
@@ -92,11 +92,12 @@ TEST(Logger, ScopedLevels_mixed_01){
   }
   log << "this should appear on stdout" << std::endl;
 
-#ifndef MUTE_GEOLOG  
-  EXPECT_EQ("geotop:this should appear on stdout\ngeotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout\ngeotop:this should appear on stdout\n", testing::internal::GetCapturedStdout());
+#ifdef MUTE_GEOLOG
+    EXPECT_EQ("", testing::internal::GetCapturedStdout());
 #else
-  EXPECT_EQ("", testing::internal::GetCapturedStdout());
+    EXPECT_EQ("geotop:this should appear on stdout\ngeotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout\ngeotop:this should appear on stdout\n", testing::internal::GetCapturedStdout());
 #endif
+    
   EXPECT_EQ("", testing::internal::GetCapturedStderr());
   
 }
@@ -121,12 +122,12 @@ TEST(Logger, ScopedLevels_mixed_02){
   }
   log << "this should appear on stdout and stderr" << std::endl;
 
-#ifndef MUTE_GEOLOG  
+#ifdef MUTE_GEOLOG
+   EXPECT_EQ("", testing::internal::GetCapturedStdout());
+  EXPECT_EQ("", testing::internal::GetCapturedStderr());
+#else
   EXPECT_EQ("geotop:this should appear on stdout and stderr\ngeotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout\ngeotop:this should appear on stdout and stderr\n", testing::internal::GetCapturedStdout());
   EXPECT_EQ("geotop:this should appear on stdout and stderr\ngeotop:this should appear on stdout and stderr\n", testing::internal::GetCapturedStderr());
-#else
-  EXPECT_EQ("", testing::internal::GetCapturedStdout());
-  EXPECT_EQ("", testing::internal::GetCapturedStderr());
 #endif
 }
 
@@ -152,12 +153,12 @@ TEST(ScopedLevels, ScopedLevels_mixed_03){
   }
   log << "this should not appear" << std::endl;
 
-#ifndef MUTE_GEOLOG  
-  EXPECT_EQ("geotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout again\n", testing::internal::GetCapturedStdout());
-  EXPECT_EQ("geotop:second:third:this should appear on stderr\n", testing::internal::GetCapturedStderr());
-#else
+#ifdef MUTE_GEOLOG
   EXPECT_EQ("", testing::internal::GetCapturedStdout());
   EXPECT_EQ("", testing::internal::GetCapturedStderr());
+#else 
+  EXPECT_EQ("geotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout again\n", testing::internal::GetCapturedStdout());
+  EXPECT_EQ("geotop:second:third:this should appear on stderr\n", testing::internal::GetCapturedStderr());
 #endif
 }
 
@@ -182,11 +183,11 @@ TEST(ScopedLevels, mixed_geolog){
   }
   geolog << "this should not appear" << std::endl;
   
-#ifndef MUTE_GEOLOG  
-  EXPECT_EQ("geotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout again\n", testing::internal::GetCapturedStdout());
-  EXPECT_EQ("geotop:second:third:this should appear on stderr\n", testing::internal::GetCapturedStderr());
-#else
+#ifdef MUTE_GEOLOG
   EXPECT_EQ("", testing::internal::GetCapturedStdout());
   EXPECT_EQ("", testing::internal::GetCapturedStderr());
+#else
+  EXPECT_EQ("geotop:second:this should appear on stdout\ngeotop:second:this should appear on stdout again\n", testing::internal::GetCapturedStdout());
+  EXPECT_EQ("geotop:second:third:this should appear on stderr\n", testing::internal::GetCapturedStderr());
 #endif
 }

--- a/tests/unit_tests/logger/meson.build
+++ b/tests/unit_tests/logger/meson.build
@@ -1,5 +1,5 @@
 _tests = ['logger_01.cc',
-          'logger_02.cc',
+       	  'logger_02.cc',
 	  'logger_03.cc']
 
 _src = ['../../../src/geotop/logger.cc']

--- a/tests/unit_tests/logger/meson.build
+++ b/tests/unit_tests/logger/meson.build
@@ -1,6 +1,6 @@
-_tests = ['logger_01.cc',
-          'logger_02.cc',
-          'logger_03.cc']
+_tests = ['logger_01.cc']
+          # 'logger_02.cc',
+          # 'logger_03.cc']
 
 _src = ['../../../src/geotop/logger.cc']
 

--- a/tests/unit_tests/logger/meson.build
+++ b/tests/unit_tests/logger/meson.build
@@ -1,5 +1,5 @@
-_tests = ['logger_01.cc']
-          # 'logger_02.cc',
+_tests = ['logger_01.cc',
+          'logger_02.cc']
           # 'logger_03.cc']
 
 _src = ['../../../src/geotop/logger.cc']

--- a/tests/unit_tests/logger/meson.build
+++ b/tests/unit_tests/logger/meson.build
@@ -1,6 +1,6 @@
 _tests = ['logger_01.cc',
-          'logger_02.cc']
-          # 'logger_03.cc']
+          'logger_02.cc',
+	  'logger_03.cc']
 
 _src = ['../../../src/geotop/logger.cc']
 


### PR DESCRIPTION
PR including modified ```logger.h``` and related unit tests (```logger``` folder) such that:
**- in  release:** ```GEOLOG_PREFIX``` is not activated and nothing is printed to ```geotop.log```;
**- in debug:** geotop.log is printed with ```GEOLOG_PREFIX``` activated.
This was done to measure time in different running cases.