### PR TITLE
print a nice table

### DIFF
--- a/src/geotop/timer.cc
+++ b/src/geotop/timer.cc
@@ -3,6 +3,79 @@
 //
 
 #include "timer.h"
+#include <algorithm>
+#include <iomanip>
 
 // the default timer
 Timer geotimer;
+
+void Timer::print_summary() {
+  // compute the total elapsed time in seconds
+  const auto t_end = high_resolution_clock::now();
+  const auto t_tot = duration_cast<duration<double>>(t_end - t_start).count();
+
+  // get the maximum length among the section (function) names
+  unsigned int max_length{0};
+  for (const auto& x : times) {
+    max_length = std::max(max_length, (unsigned int)x.first.length());
+  }
+
+  // 32 is the default width until | character
+  max_length = std::max(max_length + 1, 32u);
+  const std::string extra_dash = std::string(max_length - 32, '-');
+  const std::string extra_space = std::string(max_length - 32, ' ');
+
+  // generate a nice table
+  std::cerr << "\n\n"
+            << "+---------------------------------------------" << extra_dash
+            << "+------------"
+            << "+------------+\n"
+            << "| Total CPU time elapsed since start          " << extra_space
+            << "|";
+  std::cerr << std::setw(10) << std::setprecision(3) << std::right;
+  std::cerr << t_tot << "s |            |\n";
+  std::cerr << "|                                             " << extra_space
+            << "|            "
+            << "|            |\n";
+  std::cerr << "| Section                         " << extra_space
+            << "| no. calls |";
+  std::cerr << std::setw(10);
+  std::cerr << std::setprecision(3);
+  std::cerr << "  CPU time "
+            << " | % of total |\n";
+  std::cerr << "+---------------------------------" << extra_dash
+            << "+-----------+------------"
+            << "+------------+";
+  for (const auto& i : times) {
+    std::string name_out = i.first;
+
+    // resize the array so that it is always of the same size
+    unsigned int pos_non_space = name_out.find_first_not_of(' ');
+    name_out.erase(0, pos_non_space);
+    name_out.resize(max_length, ' ');
+    std::cerr << std::endl;
+    std::cerr << "| " << name_out;
+    std::cerr << "| ";
+    std::cerr << std::setw(9);
+    std::cerr << i.second.number_of_calls << " |";
+    std::cerr << std::setw(10);
+    std::cerr << std::fixed << std::setprecision(2);
+    std::cerr << i.second.elapsed_time << "s |";
+    std::cerr << std::setw(10);
+
+    // do not print too small percentage
+    const double fraction = i.second.elapsed_time / t_tot;
+    if (fraction > 0.001) {
+      std::cerr << std::fixed << std::setprecision(1);
+      std::cerr << fraction * 100.;
+    } else
+      std::cerr << 0.0;
+
+    std::cerr << "% |";
+  }
+  std::cerr << std::endl
+            << "+---------------------------------" << extra_dash
+            << "+-----------+"
+            << "------------+------------+\n"
+            << std::endl;
+}

--- a/src/geotop/timer.h
+++ b/src/geotop/timer.h
@@ -4,49 +4,75 @@
 #ifndef GEOTOP_TIMER_H
 #define GEOTOP_TIMER_H
 
-#include <iostream>
 #include <chrono>
+#include <iostream>
 #include <map>
 
 using namespace std::chrono;
 
+/**
+ * Utility structure to collect all the measurements
+ */
+struct ClockMeasurements {
+  unsigned int number_of_calls{};
+  double elapsed_time{};
+};
+
+/**
+ *  Simple class timer. By default, a summary of the time a function
+ *  has been called and the cpu time spent on it is reported.
+ *  TODO: The class is NOT thread safe.
+ *
+ * The design of output produced by the print_summary() function is
+ * inspired from the one of the deal.II library
+ * (github.com/dealii/dealii).
+ */
 class Timer {
-public:
-    std::map<std::string, std::pair<int,duration<double>>> times;
-    ~ Timer() {
-        for (const auto& x:times){
-            std::cerr << "---------------------------------------------------" << std::endl;
-            std::cerr << x.first << "\t\t" /** function name **/
-                      << x.second.first << "\t\t" /** n° of times the function is called **/
-                      << x.second.second.count() << std::endl; /** time passed inside the function **/
-        }
-    }
-    class ScopedTimer;
+  void print_summary();
+  high_resolution_clock::time_point t_start;
+  std::map<std::string, ClockMeasurements> times;
+ public:
+  Timer() : t_start{high_resolution_clock::now()} {}
+  ~Timer() {
+#   ifndef MUTE_GEOTIMER
+      print_summary();
+#   endif
+  }
+  class ScopedTimer;
 };
 
 /** the default timer **/
 extern Timer geotimer;
 
-class Timer::ScopedTimer {
-public:
-    high_resolution_clock::time_point t;
-    const std::string _s;
-    ScopedTimer(const std::string &s): _s{s}{
-        geotimer.times[s].first += 1;
-        t = high_resolution_clock::now();
-    }
 
-    ~ScopedTimer(){
-        auto t_end = high_resolution_clock::now();
-        geotimer.times[_s].second += duration_cast<duration<double>>(t_end-t);
-    }
+/** 
+ * utility class. The constructor takes a string and a
+ * timer. Explointing the RAII pattern, the number of function calls
+ * and the elapsed time passed inside the scope labeled with a chosen
+ * string are updated automatically.
+ */
+class Timer::ScopedTimer {
+ public:
+  const high_resolution_clock::time_point t;
+  const std::string _s;
+  Timer& _timer;
+  ScopedTimer(const std::string& s, Timer& t = geotimer)
+      : t{high_resolution_clock::now()}, _s{s}, _timer{t} {
+    _timer.times[s].number_of_calls += 1;
+  }
+
+  ~ScopedTimer() {
+    auto t_end = high_resolution_clock::now();
+    _timer.times[_s].elapsed_time +=
+        duration_cast<duration<double>>(t_end - t).count();
+  }
 };
 
-
 #ifdef MUTE_GEOTIMER
-#define GEOTIMER_PREFIX(dummy)
+#  define GEOTIMER_PREFIX(dummy)
 #else
-# define GEOTIMER_PREFIX(string) Timer::ScopedTimer __geotimer_prefix__ {string}
+#  define GEOTIMER_PREFIX(string)                                              \
+    Timer::ScopedTimer __geotimer_prefix__ { string }
 #endif
 
-#endif // GEOTOP_TIMER_H
+#endif  // GEOTOP_TIMER_H

--- a/tests/unit_tests/meson.build
+++ b/tests/unit_tests/meson.build
@@ -5,7 +5,7 @@ gtest_without_main = dependency('gtest', main: false,
                                 fallback : ['gtest', 'gtest_dep'],
                                 required: false)
 
-dirs = ['logger', 'vector', 'asserts', 'formats', 'matrix', 'tensor']
+dirs = ['logger', 'vector', 'asserts', 'formats', 'matrix', 'tensor', 'timer']
 
 if (gtest.found())
     foreach _d : dirs

--- a/tests/unit_tests/timer/timer_01.cc
+++ b/tests/unit_tests/timer/timer_01.cc
@@ -1,4 +1,8 @@
 #include <gtest/gtest.h>
 #include <timer.h>
 
-// ... to be continued ...
+TEST(ClockMeasurements, default_constructor){
+  ClockMeasurements c;
+  EXPECT_EQ(0u, c.number_of_calls);
+  EXPECT_EQ(0u, c.elapsed_time);
+}


### PR DESCRIPTION
This PR formats a bit the output of the `geotimer` timer. now the output looks like this
```
+---------------------------------------------+------------+------------+
| Total CPU time elapsed since start          |       3.5s |            |
|                                             |            |            |
| Section                         | no. calls |  CPU time  | % of total |
+---------------------------------+-----------+------------+------------+
| EnergyBalance                   |     35040 |      1.36s |      38.8% |
| PointEnergyBalance              |     35040 |      1.33s |      38.0% |
| Richards1D                      |     35040 |      0.66s |      18.8% |
| SolvePointEnergyBalance         |     35040 |      0.58s |      16.5% |
| get_all_input                   |         1 |      0.11s |       3.3% |
| time_loop                       |         1 |      3.38s |      96.6% |
| water_balance                   |     35040 |      0.70s |      19.9% |
| write_output                    |     35040 |      0.82s |      23.6% |
+---------------------------------+-----------+------------+------------+
```

I would also know from you, what are the important functions that should be reported in the final summary. Thanks