### PR TITLE
Handle MUTE_GEOLOG and MUTE_GEOTIMER in the proper way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - export PATH="$PWD/_meson:$PATH"
 
 install:
-  - meson.py build
+  - meson.py -DMUTE_GEOLOG=true -DMUTE_GEOTIMER=true build
   - cd build
   - ninja -j2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,20 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 SET( CMAKE_BUILD_TYPE RELEASE CACHE STRING "A variable which controls the type of build" )
 SET( CMAKE_CXX_FLAGS " -std=c++11 " CACHE STRING "")
 SET( CMAKE_CXX_FLAGS_DEBUG " -Wextra -Wall -g -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -O0 " CACHE STRING "" )
 SET( CMAKE_CXX_FLAGS_RELEASE " -Wextra -Wall -O2 -funroll-loops -fstrict-aliasing -Wno-narrowing -Wno-writable-strings -Wno-c++11-narrowing -DNDEBUG" CACHE STRING "" )
 SET( CMAKE_CXX_FLAGS_MINSIZEREL " -Wextra -Wall -O2 " CACHE STRING "" )
 
-project(geotop LANGUAGES CXX C)
+project(geotop LANGUAGES CXX C
+  VERSION 3.0)
 
 include_directories(src/geotop)
 include_directories(src/libraries/ascii)
 include_directories(src/libraries/fluidturtle)
 include_directories(src/libraries/geomorphology)
 include_directories(src/libraries/math)
+
+subdirs(cmake)
 
 add_executable(geotop
         src/geotop/blowingsnow.cc
@@ -107,12 +110,8 @@ add_executable(geotop
 	src/geotop/timer.cc src/geotop/timer.h
 	src/geotop/vector.h src/geotop/matrix.h src/geotop/tensor.h
 	src/geotop/rowview.h src/geotop/matrixview.h
-	src/geotop/geotop_asserts.h)
+	src/geotop/geotop_asserts.h
+	${CMAKE_BINARY_DIR}/src/geotop/version.cc)
 enable_testing()
 subdirs(tests)
 
-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/src/geotop/version.h.in ${CMAKE_BINARY_DIR}/src/geotop/version.h)
-# of course we need to inform the compiler where to look for the above header
-INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/src/geotop)
-
-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/src/geotop/config.h.in ${CMAKE_BINARY_DIR}/src/geotop/config.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,3 +119,5 @@ add_executable(geotop
 enable_testing()
 subdirs(tests)
 
+
+subdirs(cmake/final_message)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 SET( CMAKE_BUILD_TYPE RELEASE CACHE STRING "A variable which controls the type of build" )
 SET( CMAKE_CXX_FLAGS " -std=c++11 " CACHE STRING "")
 SET( CMAKE_CXX_FLAGS_DEBUG " -Wextra -Wall -g -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -O0 " CACHE STRING "" )
-SET( CMAKE_CXX_FLAGS_RELEASE " -Wextra -Wall -O2 -funroll-loops -fstrict-aliasing -Wno-narrowing -Wno-writable-strings -Wno-c++11-narrowing -DNDEBUG" CACHE STRING "" )
+SET( CMAKE_CXX_FLAGS_RELEASE " -Wextra -Wall -O2 -funroll-loops -fstrict-aliasing -DNDEBUG" CACHE STRING "" )
 SET( CMAKE_CXX_FLAGS_MINSIZEREL " -Wextra -Wall -O2 " CACHE STRING "" )
 
 project(geotop LANGUAGES CXX C
@@ -15,6 +15,10 @@ include_directories(src/libraries/geomorphology)
 include_directories(src/libraries/math)
 
 subdirs(cmake)
+# of course we need to inform the compiler where to look for
+# the config.h file
+include_directories(${CMAKE_BINARY_DIR}/src/geotop)
+
 
 add_executable(geotop
         src/geotop/blowingsnow.cc

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,1 @@
+subdirs(config)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,1 +1,2 @@
 subdirs(config)
+subdirs(compilers)

--- a/cmake/compilers/CMakeLists.txt
+++ b/cmake/compilers/CMakeLists.txt
@@ -1,0 +1,11 @@
+####################
+# set additional flag if using intel compiler
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+  SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}  -fp_speculation=safe " CACHE STRING "" FORCE)
+endif()
+
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wno-narrowing -Wno-writable-strings -Wno-c++11-narrowing" CACHE STRING "" FORCE)
+endif()

--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -1,0 +1,44 @@
+INCLUDE(CheckCXXSourceCompiles)
+
+CHECK_CXX_SOURCE_COMPILES(
+  "
+  _Pragma(\"GCC diagnostic push\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wextra\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wunknown-pragmas\\\\\\\"\")
+  _Pragma(\"GCC diagnostic ignored \\\\\\\"-Wpragmas\\\\\\\"\")
+  int main() { return 0; }
+  _Pragma(\"GCC diagnostic pop\")
+  "
+  COMPILER_HAS_DIAGNOSTIC_PRAGMA)
+
+set(MUTE_GEOLOG OFF CACHE BOOL "Silence the default logger geolog. You may want to turn this to on to gain a bit in terms of performances.")
+
+set(MUTE_GEOTIMER OFF CACHE BOOL "Silence the default timer geotimer. You may want to turn this to on to gain a bit in terms of performances.")
+
+
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/src/geotop/config.cmake.h.in ${CMAKE_BINARY_DIR}/src/geotop/config.h)
+# of course we need to inform the compiler where to look for the above header
+INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/src/geotop)
+
+
+
+
+set(VERSION ${PROJECT_VERSION})
+
+IF(EXISTS ${CMAKE_SOURCE_DIR}/.git)
+  FIND_PACKAGE(Git)
+  IF(GIT_FOUND)
+     EXECUTE_PROCESS(
+     COMMAND ${GIT_EXECUTABLE}  describe --always
+     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+     OUTPUT_VARIABLE "COMMIT"
+     ERROR_QUIET
+     OUTPUT_STRIP_TRAILING_WHITESPACE)
+     MESSAGE( STATUS "Git version: ${GEOtop_BUILD_VERSION}" )
+     ELSE()
+       SET(COMMIT "Not a git repository")
+     ENDIF()
+ENDIF()
+
+
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/src/geotop/version.cmake.cc.in ${CMAKE_BINARY_DIR}/src/geotop/version.cc @ONLY)

--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -17,11 +17,6 @@ set(MUTE_GEOTIMER OFF CACHE BOOL "Silence the default timer geotimer. You may wa
 
 
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/src/geotop/config.cmake.h.in ${CMAKE_BINARY_DIR}/src/geotop/config.h)
-# of course we need to inform the compiler where to look for the above header
-INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/src/geotop)
-
-
-
 
 set(VERSION ${PROJECT_VERSION})
 

--- a/cmake/final_message/CMakeLists.txt
+++ b/cmake/final_message/CMakeLists.txt
@@ -1,0 +1,6 @@
+message(WARNING "\n\n\n
+==================================================
+CMake support is deprecated and will be removed
+soon in favor of meson. Please try to use meson.
+If you have questions, let us know.
+==================================================")

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project('geotop','cpp',
         default_options : ['cpp_std=c++11',
 			   'buildtype=release',
 			   'warning_level=3' ],
-        version: '3.0.0')
+        version: '3.0')
 
 
 # the following lists will be populated through the inclusion of the

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,7 @@ subdir('meson')
 
 main = files('src/geotop/geotop.cc')
 
-geotop = executable('geotop', main, src_files,
+geotop = executable('geotop', main, src_files, tag,
                     include_directories: include_dirs,
                     dependencies: deps,
                     install:true,

--- a/meson/compilers/gcc/meson.build
+++ b/meson/compilers/gcc/meson.build
@@ -1,5 +1,1 @@
 # no specific flags are required for now :)
-# add_global_arguments(['-Wno-narrowing',
-#                       '-Wno-writable-strings',
-#                       '-Wno-c++11-narrowing'],
-#                      language : ['cpp','c'])

--- a/meson/config/meson.build
+++ b/meson/config/meson.build
@@ -1,5 +1,15 @@
 include_dirs += include_directories('.')
 
+# build features
+_cdata = configuration_data()
+
+# user defined options
+foreach _opt : ['MUTE_GEOLOG', 'MUTE_GEOTIMER']
+    _cdata.set(_opt, get_option(_opt))
+endforeach
+
+
+# check if compiler supports pragmas
 code = '''_Pragma("GCC diagnostic push")
   _Pragma("GCC diagnostic ignored \"-Wextra\"")
   _Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")
@@ -10,34 +20,24 @@ code = '''_Pragma("GCC diagnostic push")
 
 _pragma = _cxx.compiles(code, name: 'pragma check')
 
-_cdata = configuration_data()
-
 _cdata.set('COMPILER_HAS_DIAGNOSTIC_PRAGMA', _pragma)
-
-foreach _opt : ['MUTE_GEOLOG', 'MUTE_GEOTIMER']
-    _cdata.set(_opt, get_option(_opt))
-endforeach
 
 configure_file(output: 'config.h',
                input: _config,
                configuration: _cdata)
 
+
+# take care of reporting proper version number and commit
 _cdata = configuration_data()
 
+_cdata.set('VERSION',meson.project_version() )
 
-
-_project_git_version = '0'
-# test if we have git and if it we have it, we query the git version
-# of our project
-_git = run_command('which','git')
-if _git.returncode() == 0
-    r = run_command('git', 'describe', '--tags', '--always', '--abbrev=8')
-    _project_git_version = r.stdout().strip()
-    message('Git version: '+_project_git_version)
-endif
-
-_cdata.set_quoted('GEOtop_BUILD_VERSION', _project_git_version)
-_cdata.set_quoted('PACKAGE_STRING', meson.project_name()+' '+meson.project_version())
-
-configure_file(output: 'version.h',
+_v = configure_file(input: _vcs,
+               output:'version.cc.1',
                configuration: _cdata)
+
+tag = vcs_tag( command: ['git', 'describe', '--always'],
+               input: _v,
+               output: 'version.cc',
+               replace_string: 'XXX',
+               fallback:'Not a git repository')

--- a/meson/config/meson.build
+++ b/meson/config/meson.build
@@ -1,4 +1,4 @@
-include_dirs = [include_dirs, include_directories('.')]
+include_dirs += include_directories('.')
 
 code = '''_Pragma("GCC diagnostic push")
   _Pragma("GCC diagnostic ignored \"-Wextra\"")
@@ -11,6 +11,12 @@ code = '''_Pragma("GCC diagnostic push")
 _pragma = _cxx.compiles(code, name: 'pragma check')
 
 _cdata = configuration_data()
+
+_cdata.set('COMPILER_HAS_DIAGNOSTIC_PRAGMA', _pragma)
+
+foreach _opt : ['MUTE_GEOLOG', 'MUTE_GEOTIMER']
+    _cdata.set(_opt, get_option(_opt))
+endforeach
 
 configure_file(output: 'config.h',
                input: _config,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('MUTE_GEOLOG', type: 'boolean', value: false)
+option('MUTE_GEOTIMER', type: 'boolean', value: false)
+

--- a/src/geotop/config.cmake.h.in
+++ b/src/geotop/config.cmake.h.in
@@ -1,0 +1,11 @@
+#ifndef geotop_config_h_cmake
+#define geotop_config_h_cmake
+
+#cmakedefine COMPILER_HAS_DIAGNOSTIC_PRAGMA
+// macros DISABLE_WARNINGS and ENABLE_WARNINGS
+#include "warnings.h"
+
+#cmakedefine MUTE_GEOLOG
+#cmakedefine MUTE_GEOTIMER
+
+#endif

--- a/src/geotop/config.meson.h.in
+++ b/src/geotop/config.meson.h.in
@@ -1,9 +1,11 @@
-#ifndef geotop_config_h
-#define geotop_config_h
+#ifndef geotop_config_h_meson
+#define geotop_config_h_meson
 
 #mesondefine COMPILER_HAS_DIAGNOSTIC_PRAGMA
-
 // macros DISABLE_WARNINGS and ENABLE_WARNINGS
 #include "warnings.h"
+
+#mesondefine MUTE_GEOLOG
+#mesondefine MUTE_GEOTIMER
 
 #endif

--- a/src/geotop/geotop.cc
+++ b/src/geotop/geotop.cc
@@ -41,10 +41,10 @@
 #include "pedo.funct.h"
 #include <string>
 #include <iostream>
-#include <version.h>
-#include <logger.h>
+#include "version.h"
+#include "logger.h"
 #include <fstream>
-#include <timer.h>
+#include "timer.h"
 
 void time_loop(ALLDATA *A);
 
@@ -112,8 +112,8 @@ int main(int argc,char *argv[])
 
         if (wd == "-v"){
             std::cout << std::endl;
-            std::cout << "Version: " << PACKAGE_STRING << std::endl;
-            std::cout << "Commit :  " << GEOtop_BUILD_VERSION << std::endl;
+            std::cout << "Version: " << version() << std::endl;
+            std::cout << "Commit : " << commit() << std::endl;
             std::cout << std::endl;
             exit(10);
         }

--- a/src/geotop/logger.h
+++ b/src/geotop/logger.h
@@ -5,6 +5,8 @@
 #ifndef GEOTOP_LOGGER_H
 #define GEOTOP_LOGGER_H
 
+#include "config.h"
+
 #include <functional>
 #include <iomanip>
 #include <iostream>

--- a/src/geotop/meson.build
+++ b/src/geotop/meson.build
@@ -58,3 +58,4 @@ src_files += [files(['PBSM.cc',
     'water.balance.h',])]
 
 _config = files('config.meson.h.in')
+_vcs    = files('version.cc.in')

--- a/src/geotop/timer.h
+++ b/src/geotop/timer.h
@@ -4,6 +4,8 @@
 #ifndef GEOTOP_TIMER_H
 #define GEOTOP_TIMER_H
 
+#include "config.h"
+
 #include <chrono>
 #include <iostream>
 #include <map>

--- a/src/geotop/version.cc.in
+++ b/src/geotop/version.cc.in
@@ -1,0 +1,9 @@
+#include "version.h"
+
+const char* version(){
+  return "@VERSION@";
+}
+
+const char* commit(){
+  return "XXX";
+}

--- a/src/geotop/version.cmake.cc.in
+++ b/src/geotop/version.cmake.cc.in
@@ -1,0 +1,12 @@
+#include "version.h"
+
+#cmakedefine VERSION "@VERSION@"
+#cmakedefine COMMIT  "@COMMIT@"
+
+const char* version(){
+  return VERSION;
+}
+
+const char* commit(){
+  return COMMIT;
+}

--- a/src/geotop/version.h
+++ b/src/geotop/version.h
@@ -17,26 +17,16 @@ Any feedback will be highly appreciated.
 
 */
 
-/* @brief: Version file to define some variables: variables are set bt CMAKE
-To add other variable please edit version_cmake.h.in file
-*/
+/** 
+ * @brief: Version file to define version and commit. 
+ * 
+ * The functions are implemented in a separate .cc file to avoid
+ * recompilations
+ */
 
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
-/* Name of package */
-#define PACKAGE "${PACKAGE}"
-
-/* Git version */ 
-#define GEOtop_BUILD_VERSION "${GEOtop_BUILD_VERSION}"
-
-/* Define to the full name of this package. */
-#define PACKAGE_NAME "${PACKAGE}"
-
-/* Define to the full name and version of this package. */
-#define PACKAGE_STRING "${PACKAGE_STRING}"
-
-/* Define to the version of this package. */
-#define PACKAGE_VERSION "${PACKAGE_VERSION}"
-
+const char * version();
+const char * commit();
 #endif // __VERSION_H__

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,6 @@ set(_tests
   3D/WG1_2.0_001)
 
 foreach(_t ${_tests})
-    message("setting up ${_t} in ${CMAKE_CURRENT_SOURCE_DIR}")
         add_test(NAME "${_t}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${_t}
                 COMMAND $<TARGET_FILE:geotop> .)


### PR DESCRIPTION
The options we use like `MUTE_GEOLOG` and `MUTE_GEOTIMER` shouldn't be handled via compile flags but rather through `cmake` and `meson`. This PR adds the two options as build options. The configuration is stored in an automatically generated file (`config.h`). 

Meson and cmake have difference syntax for the starting input file to modify. So we have a `config.meson.h.in` and  `config.cmake.h.in` files. But that is transparent to the user.

Now that the two features are build options, the proper way to set them **the first time we configure** is
```
cmake -DMUTE_GEOLOG=ON -DMUTE_GEOTIMER=ON ..

meson -DMUTE_GEOLOG=true -DMUTE_GEOTIMER=true
```

from the next time

```
cmake -DMUTE_GEOLOG=ON -DMUTE_GEOTIMER=ON .

meson configure -DMUTE_GEOLOG=true -DMUTE_GEOTIMER=true
```
