### PR TITLE
add target tidy, and apply corrections proposed by clang-tidy

### DIFF
--- a/meson/custom_targets/meson.build
+++ b/meson/custom_targets/meson.build
@@ -3,14 +3,42 @@
 _source_dir = meson.source_root()
 _build_dir  = meson.build_root()
 
-_indent = find_program([_source_dir+'/utils/meson_indent'], required: false )
+###########################
+#    indent (astyle)      #
+###########################
 
-run_target('indent',
-           command: _indent)
+_indent = find_program([_source_dir+'/utils/meson_indent'], required:
+                       false )
 
-_run_clang_tidy = find_program(_source_dir+'/utils/run_clang_tidy', required: false)
+run_target('indent', command: _indent)
 
-if _run_clang_tidy.found()
-    run_target('tidy',command:
-               [_run_clang_tidy,_build_dir, _source_dir])
+###########################
+#    clang-tidy           #
+###########################
+
+# check that we have clang-tidy in our path
+_clang_tidy = find_program('clang-tidy', required: false)
+
+if _clang_tidy.found()
+    _run_clang_tidy = find_program(_source_dir+'/utils/run_clang_tidy',
+                                   required: false)
+
+    # it is recommend to run this command from a dedicated
+    # build directory defined as follows
+    #
+    # CXX=clang++ meson -Dbuildtype=plain build_tidy
+    #
+    # from build_tidy you can run
+    #
+    # ninja tidy
+    #
+    # if you want to apply the fixes suggested by the linter
+    # you can do as follows
+    #
+    # meson configure -Dtidy_args="-fix-errors"
+    # ninja tidy
+    
+    run_target('tidy',command: [_run_clang_tidy, _build_dir,
+                                _source_dir,
+                                get_option('tidy_args')])
 endif

--- a/meson/custom_targets/meson.build
+++ b/meson/custom_targets/meson.build
@@ -1,6 +1,16 @@
 # define indent target for indenting all source files of geotop
 
-_indent = find_program([meson.source_root()+'/utils/meson_indent'], required: false )
+_source_dir = meson.source_root()
+_build_dir  = meson.build_root()
+
+_indent = find_program([_source_dir+'/utils/meson_indent'], required: false )
 
 run_target('indent',
            command: _indent)
+
+_run_clang_tidy = find_program(_source_dir+'/utils/run_clang_tidy', required: false)
+
+if _run_clang_tidy.found()
+    run_target('tidy',command:
+               [_run_clang_tidy,_build_dir, _source_dir])
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,7 @@
 option('MUTE_GEOLOG', type: 'boolean', value: false)
 option('MUTE_GEOTIMER', type: 'boolean', value: false)
 
+# used to pass additional arguments when running tidy
+# target e.g. '-fix-errors' to apply fixes proposed
+# by the linter
+option('tidy_args', type: 'string', value: '', description:'additional arguments passed to clang-tidy through the target tidy') 

--- a/src/geotop/blowingsnow.cc
+++ b/src/geotop/blowingsnow.cc
@@ -660,7 +660,7 @@ void set_windtrans_snow(double Dt, double t, SNOW *snow, METEO *met,
 //*****************************************************************************************************
 
 void print_windtrans_snow(double Dt, SNOW *snow, PAR *par, TOPO *top,
-                          METEO *met, Matrix<double> *LC)
+                          METEO * /*met*/, Matrix<double> * /*LC*/)
 {
 
   long i, r, c;

--- a/src/geotop/deallocate.cc
+++ b/src/geotop/deallocate.cc
@@ -331,7 +331,7 @@ void reset_to_zero(PAR *par, SOIL *sl, LAND *land, SNOW *snow, GLACIER *glac, EN
 
     if(par->output_soil_bin == 1){
         if(strcmp(files[fTav] , string_novalue) != 0 || strcmp(files[fTavsup] , string_novalue) != 0)
-        (*sl->T_av_tensor) = 0.;
+	  (*sl->T_av_tensor) = 0.;
 
         if(strcmp(files[ficeav] , string_novalue) != 0)
             (*sl->thi_av_tensor) = 0.;

--- a/src/geotop/deallocate.cc
+++ b/src/geotop/deallocate.cc
@@ -45,7 +45,7 @@ extern T_INIT *UV;
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-void dealloc_all(TOPO *top,SOIL *sl,LAND *land,WATER *wat,CHANNEL *cnet,
+void dealloc_all(TOPO *top,SOIL * /*sl*/,LAND *land,WATER * /*wat*/,CHANNEL *cnet,
                  PAR *par,ENERGY *egy,SNOW *snow, GLACIER *glac, METEO *met, TIMES *times) {
 
     long i, j, r, l, n;

--- a/src/geotop/energy.balance.cc
+++ b/src/geotop/energy.balance.cc
@@ -56,13 +56,13 @@ extern char **files;
 #define MM 1
 #define ni 1.E-4
 #define num_iter_after_which_surfenergy_balance_not_recalculated 50
-#define Tmin_surface_below_which_surfenergy_balance_recalculated -50
+#define Tmin_surface_below_which_surfenergy_balance_recalculated (-50)
 #define num_iter_after_which_only_neutrality 10
 #define Csnow_at_T_greater_than_0 1.E20
 #define ratio_max_storage_RAIN_over_canopy_to_LSAI 0.1
 #define ratio_max_storage_SNOW_over_canopy_to_LSAI 5.0
 #define Tmax 100.0
-#define Tmin -90.0
+#define Tmin (-90.0)
 
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
@@ -226,8 +226,8 @@ short EnergyBalance(double Dt, double JD0, double JDb, double JDe,
 short PointEnergyBalance(long i, long r, long c, double Dt, double JDb,
                          double JDe, SOIL_STATE *L, SOIL_STATE *C, STATEVAR_3D *S, STATEVAR_3D *G,
                          STATE_VEG *V,
-                         Vector<double> *snowage, ALLDATA *A, double E0, double Et, double Dtplot,
-                         double W, FILE *f, double *SWupabove_v, double *Tgskin)
+                         Vector<double> *snowage, ALLDATA *A, double E0, double Et, double  /*Dtplot*/,
+                         double W, FILE * /*f*/, double *SWupabove_v, double *Tgskin)
 {
     GEOLOG_PREFIX(__func__);
     GEOTIMER_PREFIX(__func__);
@@ -2195,7 +2195,7 @@ short SolvePointEnergyBalance(short surfacemelting, double Tgd,
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-void update_soil_land(long nsurf, long n, long i, long r, long c, double fc,
+void update_soil_land(long  /*nsurf*/, long n, long i, long r, long c, double fc,
                       double Dt, ENERGY *egy, MatrixView<double> &&pa, SOIL_STATE *S, Tensor<double> *ET,
                       Matrix<double> *th)
 {
@@ -2242,7 +2242,7 @@ void update_soil_land(long nsurf, long n, long i, long r, long c, double fc,
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-void update_soil_channel(long nsurf, long n, long ch, double fc, double Dt,
+void update_soil_channel(long  /*nsurf*/, long n, long ch, double fc, double Dt,
                          ENERGY *egy, MatrixView<double> &&pa, SOIL_STATE *S, Matrix<double> *ET, Matrix<double> *th)
 {
 
@@ -2570,24 +2570,24 @@ void EnergyFluxes(double t, double Tg, long r, long c, long n, // 5 parameters
 /******************************************************************************************************************************************/
 
 void EnergyFluxes_no_rec_turbulence(double t, double Tg, long r, long c,
-                                    long n, double Tg0, double Qg0, double Tv0, double zmu, double zmT,
+                                    long n, double  /*Tg0*/, double  /*Qg0*/, double  /*Tv0*/, double zmu, double zmT,
                                     double z0s,
-                                    double d0s, double rz0s, double z0v, double d0v, double rz0v, double hveg,
+                                    double d0s, double rz0s, double  /*z0v*/, double  /*d0v*/, double  /*rz0v*/, double  /*hveg*/,
                                     double v, double Ta, double Qa,
                                     double P, double LR, double psi, double e, double fc, double LSAI,
-                                    double decaycoeff0, double Wcrn,
-                                    double Wcrnmax, double Wcsn, double Wcsnmax, double *dWcrn, double *dWcsn,
+                                    double  /*decaycoeff0*/, double  /*Wcrn*/,
+                                    double  /*Wcrnmax*/, double  /*Wcsn*/, double  /*Wcsnmax*/, double * /*dWcrn*/, double * /*dWcsn*/,
                                     Vector<double> &theta, MatrixView<double> &&soil,
-                                    RowView<double> &&land, RowView<double> &&root, PAR *par,
-                                    Vector<double> *soil_transp_layer,
-                                    double SWin, double LWin, double SWv, double *LW,
-                                    double *H, double *dH_dT, double *E, double *dE_dT, double *LWv, double *Hv,
-                                    double *LEv, double *Etrans,
+                                    RowView<double> && /*land*/, RowView<double> && /*root*/, PAR *par,
+                                    Vector<double> * /*soil_transp_layer*/,
+                                    double  /*SWin*/, double LWin, double  /*SWv*/, double *LW,
+                                    double *H, double *dH_dT, double *E, double *dE_dT, double *LWv, double * /*Hv*/,
+                                    double * /*LEv*/, double * /*Etrans*/,
                                     double *Tv, double *Qv, double *Ts, double *Qs, double *Hg0, double *Hg1,
                                     double *Eg0, double *Eg1, double *Lobukhov,
                                     double *rh, double *rv, double *rc, double *rb, double *ruc, double *rh_g,
                                     double *rv_g, double *Qg,
-                                    double *u_top, double *decay, double *Locc, double *LWup_above_v, Vector<double> &T,
+                                    double * /*u_top*/, double * /*decay*/, double * /*Locc*/, double *LWup_above_v, Vector<double> &T,
                                     Vector<double> *soil_evap_layer_bare,
                                     Vector<double> *soil_evap_layer_veg, double sky, short flagTmin, long cont)
 {

--- a/src/geotop/energy.balance.cc
+++ b/src/geotop/energy.balance.cc
@@ -2288,7 +2288,7 @@ void update_soil_channel(long  /*nsurf*/, long n, long ch, double fc, double Dt,
 /******************************************************************************************************************************************/
 
 void update_F_energy(long nbeg, long nend, Vector<double> *F, double w,
-                     Vector<double> *K, double *T)
+                     Vector<double> *K, const double *T)
 {
 
     long l;
@@ -2583,9 +2583,9 @@ void EnergyFluxes_no_rec_turbulence(double t, double Tg, long r, long c,
                                     double  /*SWin*/, double LWin, double  /*SWv*/, double *LW,
                                     double *H, double *dH_dT, double *E, double *dE_dT, double *LWv, double * /*Hv*/,
                                     double * /*LEv*/, double * /*Etrans*/,
-                                    double *Tv, double *Qv, double *Ts, double *Qs, double *Hg0, double *Hg1,
+                                    const double *Tv, const double *Qv, double *Ts, double *Qs, double *Hg0, double *Hg1,
                                     double *Eg0, double *Eg1, double *Lobukhov,
-                                    double *rh, double *rv, double *rc, double *rb, double *ruc, double *rh_g,
+                                    const double *rh, const double *rv, const double *rc, const double *rb, const double *ruc, double *rh_g,
                                     double *rv_g, double *Qg,
                                     double * /*u_top*/, double * /*decay*/, double * /*Locc*/, double *LWup_above_v, Vector<double> &T,
                                     Vector<double> *soil_evap_layer_bare,

--- a/src/geotop/energy.balance.cc
+++ b/src/geotop/energy.balance.cc
@@ -48,7 +48,6 @@ extern char *logfile;
 extern long Nl;
 extern long *opnt, nopnt, *obsn, nobsn;
 extern double **odp, *odb;
-extern long nopnt, *opnt;
 extern long i_sim, i_run;
 extern char *FailedRunFile;
 extern char **files;

--- a/src/geotop/energy.balance.cc
+++ b/src/geotop/energy.balance.cc
@@ -458,10 +458,10 @@ short PointEnergyBalance(long i, long r, long c, double Dt, double JDb,
         if (i>A->P->total_channel)
             update_snow_age(Psnow_over, (*S->T)(ns,r,c), Dt, A->P->minP_torestore_A, &((*snowage)(j)));
         avis_d=snow_albedo(avis_ground, snowD, A->P->aep, A->P->avo,
-                           A->P->snow_aging_vis, (*snowage)(j), 0., (*Zero));
+                           A->P->snow_aging_vis, (*snowage)(j), 0., (Zero));
         avis_b=avis_d;//approx
         anir_d=snow_albedo(anir_ground, snowD, A->P->aep, A->P->airo,
-                           A->P->snow_aging_nir, (*snowage)(j), 0., (*Zero));
+                           A->P->snow_aging_nir, (*snowage)(j), 0., (Zero));
         anir_b=anir_d;//approx
     }
     else
@@ -528,9 +528,9 @@ short PointEnergyBalance(long i, long r, long c, double Dt, double JDb,
     if (snowD>0)
     {
         avis_b=snow_albedo(avis_ground, snowD, A->P->aep, A->P->avo,
-                           A->P->snow_aging_vis, (*snowage)(j), cosinc, (*Fzen));
+                           A->P->snow_aging_vis, (*snowage)(j), cosinc, (Fzen));
         anir_b=snow_albedo(anir_ground, snowD, A->P->aep, A->P->airo,
-                           A->P->snow_aging_nir, (*snowage)(j), cosinc, (*Fzen));
+                           A->P->snow_aging_nir, (*snowage)(j), cosinc, (Fzen));
     }
 
     //shortwave absorbed by soil (when vegetation is not present)

--- a/src/geotop/energy.balance.h
+++ b/src/geotop/energy.balance.h
@@ -56,7 +56,7 @@ void update_soil_channel(long nsurf, long n, long ch, double fc, double Dt,
                          ENERGY *egy, MatrixView<double> &&pa, SOIL_STATE *S, Matrix<double> *ET, Matrix<double> *th);
 
 void update_F_energy(long nbeg, long nend, Vector<double> *F, double w,
-                     Vector<double> *K, double *T);
+                     Vector<double> *K, const double *T);
 
 void update_diag_dF_energy(long nbeg, long nend, Vector<double> *dF, double w,
                            Vector<double> *K);
@@ -97,9 +97,9 @@ void EnergyFluxes_no_rec_turbulence(double t, double Tg, long r, long c, long n,
                                     double SWin, // 5
                                     double LWin, double SWv, double *LW, double *H, double *dH_dT, double *E,
                                     double *dE_dT, double *LWv, double *Hv, double *LEv, // 10
-                                    double *Etrans, double *Tv, double *Qv, double *Ts, double *Qs, double *Hg0,
+                                    double *Etrans, const double *Tv, const double *Qv, double *Ts, double *Qs, double *Hg0,
                                     double *Hg1, double *Eg0, double *Eg1, double *Lobukhov, // 10
-                                    double *rh, double *rv, double *rc, double *rb, double *ruc, double *rh_g,
+                                    const double *rh, const double *rv, const double *rc, const double *rb, const double *ruc, double *rh_g,
                                     double *rv_g, double *Qg, double *u_top, double *decay, // 10
                                     double *Locc, double *LWup_above_v, Vector<double> &T,
                                     Vector<double> *soil_evap_layer_bare,

--- a/src/geotop/geotop.cc
+++ b/src/geotop/geotop.cc
@@ -99,7 +99,7 @@ int main(int argc,char *argv[])
 {
     std::string wd;
 
-    if (!argv[1])
+    if (argv[1] == nullptr)
     {
         std::cerr << "Wrong number of arguments. Abort.\n"
                   << "Example of usage:\n"

--- a/src/geotop/input.cc
+++ b/src/geotop/input.cc
@@ -62,7 +62,7 @@ extern double elapsed_time_start, cum_time, max_time;
 //****************************************************************************************************
 
 /** Subroutine which reads input data, performs  geomporphological analisys and allocates data */
-void get_all_input(long argc, char *argv[], TOPO *top, SOIL *sl, LAND *land,
+void get_all_input(long  /*argc*/, char * /*argv*/[], TOPO *top, SOIL *sl, LAND *land,
                    METEO *met, WATER *wat, CHANNEL *cnet,
                    PAR *par, ENERGY *egy, SNOW *snow, GLACIER *glac, TIMES *times)
 
@@ -2899,7 +2899,7 @@ to the soil type map");
 //***************************************************************************************************
 //***************************************************************************************************
 
-void read_optionsfile_point(PAR *par, TOPO *top, LAND *land, SOIL *sl, TIMES *times, INIT_TOOLS *IT)
+void read_optionsfile_point(PAR *par, TOPO *top, LAND *land, SOIL *sl, TIMES * /*times*/, INIT_TOOLS *IT)
 {
     GEOLOG_PREFIX(__func__);
 
@@ -3630,7 +3630,7 @@ DepthFreeSurface[mm],Hor,maxSWE[mm],Lat[deg],Long[deg]" << std::endl;
 //***************************************************************************************************
 //***************************************************************************************************
 
-void set_bedrock(INIT_TOOLS *IT, SOIL *sl, CHANNEL *cnet, PAR *par, TOPO *top, Matrix<double> *LC)
+void set_bedrock(INIT_TOOLS *IT, SOIL *sl, CHANNEL *cnet, PAR *par, TOPO *top, Matrix<double> * /*LC*/)
 {
     GEOLOG_PREFIX(__func__);
 

--- a/src/geotop/logger.cc
+++ b/src/geotop/logger.cc
@@ -16,7 +16,7 @@ Logger::Logger()
 }
 
 void Logger::pop() {
-  if (prefixes.size() > 0) {
+  if (!prefixes.empty()) {
     prefixes.pop();
   } else
     throw std::runtime_error{"You called pop() on and empty stack"};
@@ -24,7 +24,7 @@ void Logger::pop() {
 
 const std::string &Logger::prefix() const {
   static std::string s;
-  if (prefixes.size() > 0)
+  if (!prefixes.empty())
     return prefixes.top();
   else
     return s;

--- a/src/geotop/meteodata.cc
+++ b/src/geotop/meteodata.cc
@@ -880,7 +880,7 @@ short fill_RH(long imeteo, Vector<double> *Z, double **data, long nlines,
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-short fill_Pint(long imeteo, double **data, long nlines, long Prec,
+short fill_Pint(long  /*imeteo*/, double **data, long nlines, long Prec,
                 long PrecInt, long JDfrom0, char *HeaderPrecInt)
 {
 

--- a/src/geotop/meteodistr.cc
+++ b/src/geotop/meteodistr.cc
@@ -636,7 +636,7 @@ void get_dn(long nc, long nr, double deltax, double deltay, long nstns,
 void barnes_oi(short flag, Matrix<double> *xpoint, Matrix<double> *ypoint,
                Vector<double> *xstnall, Vector<double> *ystnall,
                Vector<double> *xstn, Vector<double> *ystn, Vector<double> *var, double dn,
-               double undef,
+               double  /*undef*/,
                Matrix<double> *grid, double **value_station, long metcode) {
 
     long r, c, mm, nn;

--- a/src/geotop/output.cc
+++ b/src/geotop/output.cc
@@ -2535,8 +2535,8 @@ void write_output(TIMES *times, WATER *wat, CHANNEL *cnet, PAR *par,
 //****************************************************************************************************
 //****************************************************************************************************
 
-void write_output_headers(long n, TIMES *times, WATER *wat, PAR *par,
-                          TOPO *top, LAND *land, SOIL *sl, ENERGY *egy, SNOW *snow, GLACIER *glac)
+void write_output_headers(long n, TIMES * /*times*/, WATER * /*wat*/, PAR *par,
+                          TOPO *top, LAND *land, SOIL *sl, ENERGY * /*egy*/, SNOW *snow, GLACIER * /*glac*/)
 {
     GEOLOG_PREFIX(__func__);
     /* internal auxiliary variables: */
@@ -3790,8 +3790,8 @@ Vsub/Dt[m3/s],Vchannel[m3],Qoutlandsup[m3/s],Qoutlandsub[m3/s],Qoutbottom[m3/s]\
 //***************************************************************************************************************
 
 void write_soil_output(long i, long iname, double init_date, double end_date,
-                       double JDfrom0, double JD, long day, long month, long year, long hour,
-                       long minute, Vector<double> *n, SOIL *sl, PAR *par, double psimin,
+                       double JDfrom0, double  /*JD*/, long day, long month, long year, long hour,
+                       long minute, Vector<double> *n, SOIL *sl, PAR *par, double  /*psimin*/,
                        double cosslope)
 {
     GEOLOG_PREFIX(__func__);
@@ -4135,8 +4135,8 @@ void write_soil_output(long i, long iname, double init_date, double end_date,
 //***************************************************************************************************************
 //***************************************************************************************************************
 
-void write_snow_output(long i, long iname, long r, long c, double init_date,
-                       double end_date, double JDfrom0, double JD,
+void write_snow_output(long  /*i*/, long iname, long r, long c, double init_date,
+                       double end_date, double JDfrom0, double  /*JD*/,
                        long day, long month, long year, long hour, long minute, Vector<double> *n,
                        STATEVAR_3D *snow, PAR *par, double cosslope)
 {
@@ -4550,7 +4550,7 @@ void write_soil_header(FILE *f, Vector<double> *n, RowView<double> &&dz)
 //a=2 snow(according to layers) and var used
 //a=3 snow(according to layers) and var/dz used
 
-void write_snow_header(short a, long r, long c, FILE *f, Vector<double> *n,
+void write_snow_header(short a, long  /*r*/, long  /*c*/, FILE *f, Vector<double> *n,
                        Tensor<double> *Dz)
 {
 

--- a/src/geotop/parameters.cc
+++ b/src/geotop/parameters.cc
@@ -42,7 +42,6 @@ extern long *opnt, nopnt, *obsn, nobsn, *osnw, nosnw, *oglc, noglc, *osl,
        nosl;
 extern short *ipnt, *ibsn;
 extern char **hpnt, * *hbsn, * *hsnw, * *hglc, * *hsl;
-extern char *keywords_num[num_par_number], *keywords_char[num_par_char];
 
 extern char *SuccessfulRunFile, *FailedRunFile;
 

--- a/src/geotop/parameters.cc
+++ b/src/geotop/parameters.cc
@@ -1748,7 +1748,7 @@ void assign_numeric_parameters(PAR *par, LAND *land, TIMES *times, SOIL *sl, MET
            && (long)(*itools->pa_bed)(1,jres,i) != number_novalue &&
            (long)(*itools->pa_bed)(1,ja,i) != number_novalue
            && (long)(*itools->pa_bed)(1,jns,i) != number_novalue &&
-           (long)(*itools->pa_bed)(1,jss,i) )
+           ((long)(*itools->pa_bed)(1,jss,i) != 0) )
         {
           if ( (long)(*itools->pa_bed)(1,jfc,i) == number_novalue)
             {

--- a/src/geotop/parameters.cc
+++ b/src/geotop/parameters.cc
@@ -2290,7 +2290,7 @@ char **assign_string_parameter(long beg, long end, char **string_param, char **k
 /***********************************************************/
 /***********************************************************/
 
-double assignation_number(long i, long j, char **keyword, double **num_param, long *num_param_components, double default_value,
+double assignation_number(long i, long j, char **keyword, double **num_param, const long *num_param_components, double default_value,
                           short code_error)
 {
   GEOLOG_PREFIX(__func__);

--- a/src/geotop/parameters.h
+++ b/src/geotop/parameters.h
@@ -29,7 +29,7 @@ void assign_numeric_parameters(PAR *par, LAND *land, TIMES *times, SOIL *sl, MET
 
 char **assign_string_parameter(long beg, long end, char **string_param, char **keyword);
 
-double assignation_number(long i, long j, char **keyword, double **num_param, long *num_param_components, double default_value,
+double assignation_number(long i, long j, char **keyword, double **num_param, const long *num_param_components, double default_value,
                           short code_error);
 
 char *assignation_string(long i, char **keyword, char **string_param);

--- a/src/geotop/pedo.funct.cc
+++ b/src/geotop/pedo.funct.cc
@@ -113,7 +113,7 @@ double teta_psi(double psi, double i, double s, double r, double a, double n,
 
 /*--------------------------------------------*/
 double dteta_dpsi(double psi, double i, double s, double r, double a,
-                  double n, double m, double pmin, double Ss )
+                  double n, double m, double  /*pmin*/, double Ss )
 //it is the derivative of teta with respect to psi [mm^-1]
 {
   double dteta,psisat;

--- a/src/geotop/radiation.cc
+++ b/src/geotop/radiation.cc
@@ -625,7 +625,7 @@ double cloud_transmittance(double JDbeg, double JDend, double lat,
 
   double *others;
   double tau_atm, tau_atm_sin_alpha, sin_alpha, kd, kd0;
-  double tau = (double)number_novalue;
+  auto tau = (double)number_novalue;
   long j;
 
   others = (double *)malloc(12*sizeof(double));

--- a/src/geotop/radiation.cc
+++ b/src/geotop/radiation.cc
@@ -469,7 +469,7 @@ double atm_transmittance(double X, double P, double RH, double T,
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-void longwave_radiation(short state, double pvap, double RH, double T,
+void longwave_radiation(short state, double pvap, double  /*RH*/, double T,
                         double k1, double k2, double taucloud, double *eps, double *eps_max,
                         double *eps_min)
 {

--- a/src/geotop/recovering.cc
+++ b/src/geotop/recovering.cc
@@ -32,7 +32,7 @@ extern long number_novalue;
 /******************************************************************************************************************************************/
 
 void assign_recovered_map(short old, long n, char *name, Matrix<double> *assign,
-                          PAR *par, Matrix<double> *Zdistr)
+                          PAR * /*par*/, Matrix<double> *Zdistr)
 {
 
   long r, c;
@@ -67,7 +67,7 @@ void assign_recovered_map(short old, long n, char *name, Matrix<double> *assign,
 /******************************************************************************************************************************************/
 
 void assign_recovered_map_vector(short old, long n, char *name,
-                                 Vector<double> *assign, Matrix<long> *rc, PAR *par, Matrix<double> *Zdistr)
+                                 Vector<double> *assign, Matrix<long> *rc, PAR * /*par*/, Matrix<double> *Zdistr)
 {
 
   long i, r, c;
@@ -102,7 +102,7 @@ void assign_recovered_map_vector(short old, long n, char *name,
 /******************************************************************************************************************************************/
 
 void assign_recovered_map_long(short old, long n, char *name,
-                               Matrix<long> *assign, PAR *par, Matrix<double> *Zdistr)
+                               Matrix<long> *assign, PAR * /*par*/, Matrix<double> *Zdistr)
 {
 
   long r, c;
@@ -136,7 +136,7 @@ void assign_recovered_map_long(short old, long n, char *name,
 /******************************************************************************************************************************************/
 
 void assign_recovered_tensor(short old, long n, char *name,
-                             Tensor<double> *assign, PAR *par, Matrix<double> *Zdistr)
+                             Tensor<double> *assign, PAR * /*par*/, Matrix<double> *Zdistr)
 {
 
   long r, c, l;
@@ -178,7 +178,7 @@ void assign_recovered_tensor(short old, long n, char *name,
 /******************************************************************************************************************************************/
 
 void assign_recovered_tensor_vector(short old, long n, char *name, Matrix<double> *assign,
-                                    Matrix<long> *rc, PAR *par, Matrix<double> *Zdistr)
+                                    Matrix<long> *rc, PAR * /*par*/, Matrix<double> *Zdistr)
 {
 
   long r, c, i, l;

--- a/src/geotop/snow.cc
+++ b/src/geotop/snow.cc
@@ -51,7 +51,7 @@ extern char *FailedRunFile;
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 //Jordan et al., 1999
-double rho_newlyfallensnow(double u, double Tatm, double Tfreez)
+double rho_newlyfallensnow(double u, double Tatm, double  /*Tfreez*/)
 {
 
   double rho,T;
@@ -522,7 +522,7 @@ double internal_energy(double w_ice, double w_liq, double T)
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-void from_internal_energy(double a, long r, long c, double h, double *w_ice,
+void from_internal_energy(double a, long  /*r*/, long  /*c*/, double h, double *w_ice,
                           double *w_liq, double *T)
 {
 
@@ -660,7 +660,7 @@ short set_snow_max(double a, long r, long c, STATEVAR_3D *snow, long l1,
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-short set_snowice_min(double a, long r, long c, STATEVAR_1D *snow, long l1,
+short set_snowice_min(double  /*a*/, long  /*r*/, long  /*c*/, STATEVAR_1D *snow, long l1,
                       long l2, double wicemin)
 {
 
@@ -835,7 +835,7 @@ void initialize_snow(long r, long c, long l, STATEVAR_3D *snow)
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-void show_Dminmax(long r, long c, double *Dmin, double *Dmax, long n)
+void show_Dminmax(long  /*r*/, long  /*c*/, double *Dmin, double *Dmax, long n)
 {
 
   long l;

--- a/src/geotop/struct.geotop.cc
+++ b/src/geotop/struct.geotop.cc
@@ -21,8 +21,7 @@ STATEVAR_3D::STATEVAR_3D(double nan, long nl, long nr, long nc) :
   *w_liq = 0.;
 }
 
-STATEVAR_3D::~STATEVAR_3D() {
-}
+STATEVAR_3D::~STATEVAR_3D() = default;
 
 SOIL_STATE::SOIL_STATE(const long n, const long nl) :
 

--- a/src/geotop/timer.cc
+++ b/src/geotop/timer.cc
@@ -10,7 +10,7 @@
 Timer geotimer;
 
 void Timer::print_summary() {
-  if (times.size() == 0 ) return; // do not print empty table
+  if (times.empty() ) return; // do not print empty table
   // compute the total elapsed time in seconds
   const auto t_end = high_resolution_clock::now();
   const auto t_tot = duration_cast<duration<double>>(t_end - t_start).count();

--- a/src/geotop/turbulence.cc
+++ b/src/geotop/turbulence.cc
@@ -304,19 +304,19 @@ double CZ(short state, double zmeas, double z0, double d0, double L,
 
   if (state==1)     //both instability and stability considered
     {
-      c=cz(zmeas,z0,d0,L,(Psi),(*PsiStab));
+      c=cz(zmeas,z0,d0,L,(Psi),(PsiStab));
     }
   else if (state==2)    //instability considered & stability not considered
     {
-      c=cz(zmeas,z0,d0,L,(Psi),(*Zero));
+      c=cz(zmeas,z0,d0,L,(Psi),(Zero));
     }
   else if (state==3)    //instability not considered & stability considered
     {
-      c=cz(zmeas,z0,d0,L,(*Zero),(*PsiStab));
+      c=cz(zmeas,z0,d0,L,(Zero),(PsiStab));
     }
   else if (state==4)    //both instability and stability not considered
     {
-      c=cz(zmeas,z0,d0,L,(*Zero),(*Zero));
+      c=cz(zmeas,z0,d0,L,(Zero),(Zero));
     }
   else
     {
@@ -451,21 +451,21 @@ void Businger(short a, double zmu, double zmt, double d0, double z0, double v,
       if (cont>0) tol=10*T_star+100*u_star+1000*Q_star;
 
       //Conductances
-      Star(a, zmu, z0, d0, L, 0.0, v, 1.0, 0.0, 1.0, &u_star, &cm, &z0v, (*Psim),
-           (*roughT)); //momentum
+      Star(a, zmu, z0, d0, L, 0.0, v, 1.0, 0.0, 1.0, &u_star, &cm, &z0v, (Psim),
+           (roughT)); //momentum
       if (z0_z0t==0.0)  //rigid surface
         {
           Star(a, zmt, z0, d0, L, u_star, DT, u_star*z0/1.4E-5, 1.0, 0.0, &T_star, &ch,
-               &z0t, (*Psih), (*roughT)); //heat flux
+               &z0t, (Psih), (roughT)); //heat flux
           Star(a, zmt, z0, d0, L, u_star, DQ, u_star*z0/1.4E-5, 1.0, 0.0, &Q_star, &cv,
-               &z0q, (*Psih), (*roughQ)); //water vapour flux
+               &z0q, (Psih), (roughQ)); //water vapour flux
         }
       else    //bending surface
         {
           Star(a, zmt, z0, d0, L, u_star, DT, 1.0, 0.0, 1.0/z0_z0t, &T_star, &ch, &z0t,
-               (*Psih), (*roughT)); //heat flux
+               (Psih), (roughT)); //heat flux
           Star(a, zmt, z0, d0, L, u_star, DQ, 1.0, 0.0, 1.0/z0_z0t, &Q_star, &cv, &z0q,
-               (*Psih), (*roughQ)); //water vapour flux
+               (Psih), (roughQ)); //water vapour flux
         }
 
       //Obukhov length

--- a/src/geotop/turbulence.cc
+++ b/src/geotop/turbulence.cc
@@ -34,7 +34,7 @@ extern char *FailedRunFile;
 
 void aero_resistance(double zmu, double zmt, double z0, double d0,
                      double z0_z0t, double v, double Ta, double T, double Qa,
-                     double Q, double P, double gmT, double *Lobukhov, double *rm, double *rh,
+                     double Q, double  /*P*/, double gmT, double *Lobukhov, double *rm, double *rh,
                      double *rv, short state_turb,
                      short MO, long maxiter)
 {
@@ -134,7 +134,7 @@ double Psih(double z)
 }
 
 //****Zero
-double Zero(double z)
+double Zero(double  /*z*/)
 {
   return (0.0);
 }
@@ -335,7 +335,7 @@ double CZ(short state, double zmeas, double z0, double d0, double L,
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-void Star(short a, double zmeas, double z0, double d0, double L, double u,
+void Star(short a, double zmeas, double z0, double d0, double L, double  /*u*/,
           double delta, double M, double N, double R,
           double *var, double *c, double *z0v, double (*Psi)(double z),
           double (*roughness)(double x, double y, double z) )
@@ -546,7 +546,7 @@ double latent(double Ts, double Le)
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-void find_actual_evaporation_parameters(long R, long C, double *alpha,
+void find_actual_evaporation_parameters(long  /*R*/, long  /*C*/, double *alpha,
                                         double *beta, Vector<double> *evap_layer, Vector<double> &theta,
                                         MatrixView<double> &&soil, Vector<double> &T, double psi, double P, double rv,
                                         double Ta,

--- a/src/geotop/vegetation.cc
+++ b/src/geotop/vegetation.cc
@@ -773,7 +773,7 @@ void canopy_evapotranspiration(double rbv, double Tv, double Qa, double Pa,
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-void veg_transmittance(short stabcorr_incanopy, double v, double u_star,
+void veg_transmittance(short stabcorr_incanopy, double  /*v*/, double u_star,
                        double u_top, double Hveg, double z0soil, double z0veg, double d0veg,
                        double LSAI, double decaycoeff0, double Lo, double Loc, double *rb,
                        double *rh, double *decay)

--- a/src/geotop/vegetation.cc
+++ b/src/geotop/vegetation.cc
@@ -300,7 +300,7 @@ void canopy_fluxes(long r, long c, double Tv, double Tg, double Ta,
       u_star=sqrt(v/(*rm));
 
       //wind speed at the top of the canopy
-      *u_top=(u_star/ka)*CZ(MO, hveg, z0, d0, *Lobukhov, (*Psim));
+      *u_top=(u_star/ka)*CZ(MO, hveg, z0, d0, *Lobukhov, (Psim));
 
       //iteration for Loc (within canopy Obukhov length)
       cont=0;

--- a/src/geotop/water.balance.cc
+++ b/src/geotop/water.balance.cc
@@ -89,8 +89,8 @@ short water_balance(double Dt, double JD0, double JD1, double JD2,
 
         //surface flow: 1st half of time step
         start=clock();
-        supflow(adt->P->DDland, adt->P->DDchannel, Dt / 2., adt->I->time, L->P->row(0), (*adt->W->h_sup.get()), C->P->row(0),
-                (*adt->C->h_sup.get()), adt->T.get(), adt->L.get(), adt->W.get(), adt->C.get(), adt->P.get(), adt->M.get(),
+        supflow(adt->P->DDland, adt->P->DDchannel, Dt / 2., adt->I->time, L->P->row(0), (*adt->W->h_sup), C->P->row(0),
+                (*adt->C->h_sup), adt->T.get(), adt->L.get(), adt->W.get(), adt->C.get(), adt->P.get(), adt->M.get(),
                 Vsup, Voutnet, Voutlandsup, &mm1, &mm2, &mmo);
         end=clock();
 
@@ -155,8 +155,8 @@ short water_balance(double Dt, double JD0, double JD1, double JD2,
 
         //surface flow: 2nd half of time step
         start=clock();
-        supflow(adt->P->DDland, adt->P->DDchannel, Dt / 2., adt->I->time, L->P->row(0), (*adt->W->h_sup.get()), C->P->row(0),
-                (*adt->C->h_sup.get()), adt->T.get(), adt->L.get(), adt->W.get(), adt->C.get(), adt->P.get(), adt->M.get(),
+        supflow(adt->P->DDland, adt->P->DDchannel, Dt / 2., adt->I->time, L->P->row(0), (*adt->W->h_sup), C->P->row(0),
+                (*adt->C->h_sup), adt->T.get(), adt->L.get(), adt->W.get(), adt->C.get(), adt->P.get(), adt->M.get(),
                 Vsup, Voutnet, Voutlandsup, &mm1, &mm2, &mmo);
         end=clock();
 

--- a/src/geotop/water.balance.cc
+++ b/src/geotop/water.balance.cc
@@ -942,7 +942,7 @@ double cm_h(double cm0, double h, double h_thres1, double h_thres2)
 /******************************************************************************************************************************************/
 //cnt is the counter of Li Lp Lx (lower diagonal without diagonal)
 
-int find_matrix_K_3D(double Dt, SOIL_STATE *SL, SOIL_STATE *SC,
+int find_matrix_K_3D(double  /*Dt*/, SOIL_STATE *SL, SOIL_STATE *SC,
                      Vector<double> *Lx, Matrix<double> *Klat, Matrix<double> *Kbottom_l,
                      Vector<double> *Kbottom_ch, ALLDATA *adt, Vector<double> *H)
 {
@@ -1455,7 +1455,7 @@ int find_matrix_K_3D(double Dt, SOIL_STATE *SL, SOIL_STATE *SC,
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-int find_matrix_K_1D(long c, double Dt, SOIL_STATE *L, Vector<double> *Lx,
+int find_matrix_K_1D(long c, double  /*Dt*/, SOIL_STATE *L, Vector<double> *Lx,
                      Matrix<double> *Klat, Matrix<double> *Kbottom, ALLDATA *adt, Vector<double> *H)
 {
 
@@ -1992,7 +1992,7 @@ double find_3Ddistance(double horizontal_distance, double vertical_distance)
 /******************************************************************************************************************************************/
 
 void find_dt_max(short DD, double Courant, RowView<double> &&h, LAND *land, TOPO *top,
-                 CHANNEL *cnet, PAR *par, METEO *met, double t, double *dt)
+                 CHANNEL *cnet, PAR *par, METEO * /*met*/, double  /*t*/, double *dt)
 {
 
     double q, ds=sqrt((*UV->U)(1)*(*UV->U)(2)), area, Vmax, H;
@@ -2235,7 +2235,7 @@ void supflow(short DDland, short DDch, double Dt, double t, RowView<double> &&h,
 /******************************************************************************************************************************************/
 
 void find_dt_max_chla(double Courant, RowView<double> &&h, RowView<double> &&hch, TOPO *top,
-                      CHANNEL *cnet, PAR *par, double t, double *dt)
+                      CHANNEL *cnet, PAR *par, double  /*t*/, double *dt)
 {
 
     double q, ds=sqrt((*UV->U)(1)*(*UV->U)(2)), area, areach, Vmax, H, Hch, DH;
@@ -2313,7 +2313,7 @@ void find_dt_max_chla(double Courant, RowView<double> &&h, RowView<double> &&hch
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-void supflow_chla(double Dt, double t, RowView<double> &&h, RowView<double> &&hch, TOPO *top, WATER *wat,
+void supflow_chla(double Dt, double t, RowView<double> &&h, RowView<double> &&hch, TOPO *top, WATER * /*wat*/,
                   CHANNEL *cnet, PAR *par,
                   Vector<double> *Vsup, long *cnt)
 {
@@ -2438,7 +2438,7 @@ void supflow_chla(double Dt, double t, RowView<double> &&h, RowView<double> &&hc
 /******************************************************************************************************************************************/
 
 void find_dt_max_channel(short DDcomplex, double Courant, RowView<double> &&h,
-                         TOPO *top, CHANNEL *cnet, PAR *par, LAND *land, double t, double *dt)
+                         TOPO *top, CHANNEL *cnet, PAR *par, LAND * /*land*/, double  /*t*/, double *dt)
 {
 
     long r, c, ch, R, C;

--- a/src/libraries/ascii/tabs.cc
+++ b/src/libraries/ascii/tabs.cc
@@ -774,7 +774,7 @@ long count_lines(char *meteo_file_name, long comment_char, long sep_char)
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-double **read_datamatrix(FILE *f, char *filename, long comment_char,
+double **read_datamatrix(FILE *f, char * /*filename*/, long comment_char,
                          long sep_char, long number_lines, long components_header)
 {
   GEOLOG_PREFIX(__func__);

--- a/src/libraries/ascii/tabs.cc
+++ b/src/libraries/ascii/tabs.cc
@@ -19,12 +19,12 @@
 
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <math.h>
-#include <time.h>
-#include <ctype.h>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <cmath>
+#include <ctime>
+#include <cctype>
 
 #include "tabs.h"
 

--- a/src/libraries/ascii/tabs.cc
+++ b/src/libraries/ascii/tabs.cc
@@ -274,7 +274,7 @@ short readline_par(FILE *f, long comment_char, long sepfield_char,
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-double find_number(long *vector, long lengthvector)
+double find_number(const long *vector, long lengthvector)
 {
   GEOLOG_PREFIX(__func__);
   double N = 0.0, Nexp = 0.0;
@@ -357,7 +357,7 @@ double find_number(long *vector, long lengthvector)
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-char *find_string(long *vector, long lengthvector)
+char *find_string(const long *vector, long lengthvector)
 {
   GEOLOG_PREFIX(__func__);
 
@@ -378,7 +378,7 @@ char *find_string(long *vector, long lengthvector)
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-double *find_number_vector(double *vector, long lengthvector)
+double *find_number_vector(const double *vector, long lengthvector)
 {
   GEOLOG_PREFIX(__func__);
 
@@ -398,7 +398,7 @@ double *find_number_vector(double *vector, long lengthvector)
 /******************************************************************************************************************************************/
 /******************************************************************************************************************************************/
 
-long *find_string_int(long *vector, long lengthvector)
+long *find_string_int(const long *vector, long lengthvector)
 {
   GEOLOG_PREFIX(__func__);
 

--- a/src/libraries/ascii/tabs.h
+++ b/src/libraries/ascii/tabs.h
@@ -27,13 +27,13 @@ short readline_par(FILE *f, long comment_char, long sepfield_char,
                    long *keylength, long *string, long *stringlength, double *number,
                    long *numberlength, short *endoffile);
 
-double find_number(long *vector, long lengthvector);
+double find_number(const long *vector, long lengthvector);
 
-char *find_string(long *vector, long lengthvector);
+char *find_string(const long *vector, long lengthvector);
 
-double *find_number_vector(double *vector, long lengthvector);
+double *find_number_vector(const double *vector, long lengthvector);
 
-long *find_string_int(long *vector, long lengthvector);
+long *find_string_int(const long *vector, long lengthvector);
 
 /*----------------------------------------------------------------------------------------------------------*/
 

--- a/src/libraries/fluidturtle/alloc.cc
+++ b/src/libraries/fluidturtle/alloc.cc
@@ -17,7 +17,7 @@ float *vector(long nl, long nh)
 
   v = (float *) malloc((size_t) ((nh - nl + 1 + NR_END) * sizeof(float)));
 
-  if (!v) t_error("allocation failure in fvector()");
+  if (v == nullptr) t_error("allocation failure in fvector()");
 
   return v - nl + NR_END;
 
@@ -43,7 +43,7 @@ float **matrix(long nrl, long nrh, long ncl, long nch)
 
   m = (float **) malloc((size_t) ((rows + NR_END) * sizeof(float *)));
 
-  if (!m) t_error("Allocation failure 1 in matrix()");
+  if (m == nullptr) t_error("Allocation failure 1 in matrix()");
 
   m += NR_END;
 
@@ -53,7 +53,7 @@ float **matrix(long nrl, long nrh, long ncl, long nch)
 
   m[nrl] = (float *) malloc((size_t) ((rows * cols + NR_END) * sizeof(float)));
 
-  if (!m) t_error("Allocation failure 2 in matrix()");
+  if (m == nullptr) t_error("Allocation failure 2 in matrix()");
 
   m[nrl] += NR_END;
 

--- a/src/libraries/fluidturtle/t_io.cc
+++ b/src/libraries/fluidturtle/t_io.cc
@@ -2,7 +2,7 @@
 
 #include <sys/stat.h>
 #include <libgen.h>
-#include <limits.h>
+#include <climits>
 
 extern const char *WORKING_DIRECTORY ;
 

--- a/src/libraries/math/util_math.cc
+++ b/src/libraries/math/util_math.cc
@@ -77,7 +77,7 @@ short tridiag(short a, long r, long c, long nx, Vector<double> *diag_inf,
 /*----------------------------------------------------------------------------------------------------------*/
 
 
-short tridiag2(short a, long r, long c, long nbeg, long nend,
+short tridiag2(short  /*a*/, long  /*r*/, long  /*c*/, long nbeg, long nend,
                Vector<double> *ld, Vector<double> *d, Vector<double> *ud, Vector<double> *b,
                Vector<double> *e)
 

--- a/utils/run_clang_tidy
+++ b/utils/run_clang_tidy
@@ -6,4 +6,34 @@ shift
 SOURCE_DIR=$1
 shift
 
-clang-tidy -p ${BUILD_DIR} -checks="-*,performance-*,modernize-*,-modernize-make-unique" ${SOURCE_DIR}/src/geotop/*.cc  -header-filter=${SOURCE_DIR}/src/geotop/*.h
+CFILE=${BUILD_DIR}/compile_commands.json # compile file
+TFILE=${BUILD_DIR}/.compile_commands.json # temporary file
+
+# check we are in proper build dir
+if test ! -f  $CFILE ;then
+    echo "*** Something wrong happend. Please reconfigure meson. ***"
+    exit 1
+fi
+
+cp $CFILE $TFILE
+cat $TFILE | sed 's/-pipe//g' > ${CFILE}
+
+
+# no spaces
+CHECKS="-*,\
+performance-*,\
+modernize-*,\
+-modernize-make-unique,\
+bugprone-*"
+
+CHECKS="-*,misc*"
+
+SRC="${SOURCE_DIR}/src/geotop/*.cc\
+     ${SOURCE_DIR}/src/libraries/*/*.cc"
+
+HEAD="${SOURCE_DIR}/src/geotop/*.h ${SOURCE_DIR}/src/libraries/{ascii,fluidturtle,geomorphology,math}/*.h"
+
+clang-tidy -p ${BUILD_DIR} -checks="${CHECKS}" ${SRC}  \
+	   -header-filter="${HEAD}" -quiet
+
+mv $TFILE $CFILE

--- a/utils/run_clang_tidy
+++ b/utils/run_clang_tidy
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+BUILD_DIR=$1
+shift
+
+SOURCE_DIR=$1
+shift
+
+clang-tidy -p ${BUILD_DIR} -checks="-*,performance-*,modernize-*,-modernize-make-unique" ${SOURCE_DIR}/src/geotop/*.cc  -header-filter=${SOURCE_DIR}/src/geotop/*.h

--- a/utils/run_clang_tidy
+++ b/utils/run_clang_tidy
@@ -6,27 +6,29 @@ shift
 SOURCE_DIR=$1
 shift
 
+ARGS=$1
+shift
+
 CFILE=${BUILD_DIR}/compile_commands.json # compile file
 TFILE=${BUILD_DIR}/.compile_commands.json # temporary file
 
-# check we are in proper build dir
-if test ! -f  $CFILE ;then
-    echo "*** Something wrong happend. Please reconfigure meson. ***"
-    exit 1
-fi
-
 cp $CFILE $TFILE
 cat $TFILE | sed 's/-pipe//g' > ${CFILE}
-
 
 # no spaces
 CHECKS="-*,\
 performance-*,\
 modernize-*,\
 -modernize-make-unique,\
-bugprone-*"
+bugprone-*,\
+misc-*,\
+readability-*,\
+-readability-function-size,\
+-readability-braces-around-statements,\
+-readability-inconsistent-declaration-parameter-name,\
+-readability-else-after-return"
 
-CHECKS="-*,misc*"
+# CHECKS="-*,"
 
 SRC="${SOURCE_DIR}/src/geotop/*.cc\
      ${SOURCE_DIR}/src/libraries/*/*.cc"
@@ -34,6 +36,6 @@ SRC="${SOURCE_DIR}/src/geotop/*.cc\
 HEAD="${SOURCE_DIR}/src/geotop/*.h ${SOURCE_DIR}/src/libraries/{ascii,fluidturtle,geomorphology,math}/*.h"
 
 clang-tidy -p ${BUILD_DIR} -checks="${CHECKS}" ${SRC}  \
-	   -header-filter="${HEAD}" -quiet
+	   -header-filter="${HEAD}" -quiet $ARGS
 
 mv $TFILE $CFILE


### PR DESCRIPTION
In this PR I introduced the target `tidy` to run the linter `clang-tidy` with some checks. I also applied the corrections proposed by the linter:
 - comment out unused argument in functions
 - remove redundant pointer dereferentiations
 - remove redundant declaration of variables
 - do not use deprecated headers
 - using `cointainer.empty()` instead of `container.size() == 0`
 - add `const` when was easy to guess