### PR TITLE
fix omp dependency

### DIFF
--- a/meson/dependencies/openMP/meson.build
+++ b/meson/dependencies/openMP/meson.build
@@ -1,7 +1,17 @@
 omp = dependency('openmp', required: false)
 
 if not omp.found()
-    error('\n\nYour compiler does not support openMP. Please reconfigure with -DWITH_OMP=false\n')
+    # it might be your meson is a bit old
+    compiler = meson.get_compiler('cpp')
+    _c = compiler.has_argument('-fopenmp')
+    _l = compiler.has_link_argument('-fopenmp')
+    _h = compiler.has_header('omp.h')
+    if not (_c and _l and _h)
+        error('\n\nYour compiler does not support openMP. Please reconfigure with -DWITH_OMP=false\n')
+    else
+        omp = declare_dependency(compile_args:'-fopenmp',
+                                 link_args:'-fopenmp')
+    endif
 endif
 
 deps += omp

--- a/meson/dependencies/openMP/meson.build
+++ b/meson/dependencies/openMP/meson.build
@@ -4,9 +4,8 @@ if not omp.found()
     # it might be your meson is a bit old
     compiler = meson.get_compiler('cpp')
     _c = compiler.has_argument('-fopenmp')
-    _l = compiler.has_link_argument('-fopenmp')
     _h = compiler.has_header('omp.h')
-    if not (_c and _l and _h)
+    if not (_c and _h)
         error('\n\nYour compiler does not support openMP. Please reconfigure with -DWITH_OMP=false\n')
     else
         omp = declare_dependency(compile_args:'-fopenmp',


### PR DESCRIPTION
meson older than `0.46` does not have the module `openmp`, so we need to check by hand if the compiler support `-fopenmp`