### PR TITLE
Corrected values in geotop.inpts for Montacini + removing pragma from water balance

### DIFF
--- a/src/geotop/water.balance.cc
+++ b/src/geotop/water.balance.cc
@@ -1736,7 +1736,6 @@ int find_f_3D(double Dt, Vector<double> *f, ALLDATA *adt, SOIL_STATE *L,
     long i;
     long n=(Nl+1)*adt->P->total_pixel;
 
-    #pragma omp parallel for
     for (i=1; i<=H->nh; i++)
     {
       long  l, r, c, j, sy, ch, bc;

--- a/tests/3D/Muntatschini_ref_005/geotop.inpts
+++ b/tests/3D/Muntatschini_ref_005/geotop.inpts
@@ -30,10 +30,10 @@ DtPlotPoint = 1
 DtPlotBasin = 1
 
 ! Output maps Dt in hours 
-OutputSoilMaps = 120
-OutputSurfEBALMaps = 120
-OutputMeteoMaps = 120
-OutputSnowMaps = 120
+OutputSoilMaps = 2
+OutputSurfEBALMaps = 2
+OutputMeteoMaps = 2
+OutputSnowMaps = 2
 
 !=======================================
 ! METEO STATIONS Input


### PR DESCRIPTION
PR with:

- corrected value of a parameter  in ```geotop.inpts``` for **Muntatschini_ref_005**.
 The value  was repeated and it wasn't take into account during the run BUT it could be misleading.
In the future all ```geotop.inpts``` will be revised to avoid things like this (see open issue #80 )

- no more pragma in water balance since no ```omp parallel for``` wasn't formally correct (all the functions inside the parallel section should be thread safe)
