### PR TITLE
Add meteoIO library to our build system tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,12 @@ SET( CMAKE_CXX_FLAGS_DEBUG " -Wextra -Wall -g -Wshadow -Wpointer-arith -Wcast-qu
 SET( CMAKE_CXX_FLAGS_RELEASE " -Wextra -Wall -O2 -funroll-loops -fstrict-aliasing -DNDEBUG" CACHE STRING "" )
 SET( CMAKE_CXX_FLAGS_MINSIZEREL " -Wextra -Wall -O2 " CACHE STRING "" )
 
-subdirs(cmake)
-
 
 project(geotop LANGUAGES CXX C
   VERSION 3.0)
+
+add_subdirectory(cmake)
+
 
 
 include_directories(src/geotop)
@@ -31,6 +32,7 @@ include_directories(src/libraries/math)
 # the config.h file
 include_directories(${CMAKE_BINARY_DIR}/src/geotop)
 
+include_directories(${METEOIO_INCLUDE_DIR})
 
 add_executable(geotop
         src/geotop/blowingsnow.cc
@@ -116,8 +118,11 @@ add_executable(geotop
 	src/geotop/geotop_asserts.h
 	src/geotop/math.optim.h
 	${CMAKE_BINARY_DIR}/src/geotop/version.cc)
+
+target_link_libraries(geotop ${METEOIO_LIBRARY})
+
 enable_testing()
-subdirs(tests)
 
+add_subdirectory(tests)
 
-subdirs(cmake/final_message)
+add_subdirectory(cmake/final_message)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,2 +1,3 @@
 subdirs(config)
 subdirs(compilers)
+subdirs(meteoIO)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,3 +1,3 @@
-subdirs(config)
-subdirs(compilers)
-subdirs(meteoIO)
+add_subdirectory(config)
+add_subdirectory(compilers)
+add_subdirectory(meteoIO)

--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -19,6 +19,10 @@ set(MATH_OPTIM OFF CACHE BOOL "Use math optimizations. You may want to turn this
 
 set(WITH_OMP OFF CACHE BOOL "Use openMP framework")
 
+set(WITH_METEOIO OFF CACHE BOOL "Use MeteoIO library")
+
+set(METEOIO_DIR '' CACHE PATH "Prefix of MeteoIO library installation")
+
 
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/src/geotop/config.cmake.h.in ${CMAKE_BINARY_DIR}/src/geotop/config.h)
 

--- a/cmake/meteoIO/CMakeLists.txt
+++ b/cmake/meteoIO/CMakeLists.txt
@@ -1,9 +1,16 @@
 ####################
 
 if(WITH_METEOIO)
-  IF (METEOIO_DIR)
-    set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -L${METEOIO_DIR}/lib -I${METEOIO_DIR}/include -lmeteoio" CACHE STRING "" FORCE)
-  else()
-    set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -lmeteoio" CACHE STRING "" FORCE)  
-  endif()
+
+  find_path(METEOIO_INCLUDE_DIR meteoio/Config.h
+    PATHS
+    /usr/include
+    /usr/local/include
+    ${METEOIO_DIR}/include
+    )
+
+  find_library(METEOIO_LIBRARY
+    NAMES meteoio
+    PATHS /usr/lib64 ${METEOIO_DIR}/lib)
+
 endif()  

--- a/cmake/meteoIO/CMakeLists.txt
+++ b/cmake/meteoIO/CMakeLists.txt
@@ -1,0 +1,9 @@
+####################
+
+if(WITH_METEOIO)
+  IF (METEOIO_DIR)
+    set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -L${METEOIO_DIR}/lib -I${METEOIO_DIR}/include -lmeteoio" CACHE STRING "" FORCE)
+  else()
+    set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -lmeteoio" CACHE STRING "" FORCE)  
+  endif()
+endif()  

--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,6 @@ geotop = executable('geotop', main, src_files, tag,
                     dependencies: deps,
                     install:true,
                     install_rpath: rpaths)
-message('------------------ ' +rpaths)
 
 # set up tests
 subdir('tests')

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ geotop = executable('geotop', main, src_files, tag,
                     dependencies: deps,
                     install:true,
                     install_rpath: rpaths)
+message('------------------ ' +rpaths)
 
 # set up tests
 subdir('tests')

--- a/meson/config/meson.build
+++ b/meson/config/meson.build
@@ -4,10 +4,10 @@ include_dirs += include_directories('.')
 _cdata = configuration_data()
 
 # user defined options
-foreach _opt : ['MUTE_GEOLOG', 'MUTE_GEOTIMER', 'MATH_OPTIM', 'WITH_OMP']
+foreach _opt : ['MUTE_GEOLOG', 'MUTE_GEOTIMER', 'MATH_OPTIM', 'WITH_OMP',
+                'WITH_METEOIO']
     _cdata.set(_opt, get_option(_opt))
 endforeach
-
 
 # check if compiler supports pragmas
 code = '''_Pragma("GCC diagnostic push")

--- a/meson/dependencies/meson.build
+++ b/meson/dependencies/meson.build
@@ -1,3 +1,7 @@
 if get_option('WITH_OMP')
     subdir('openMP')
 endif
+
+if get_option('WITH_METEOIO')
+    subdir('meteoIO')
+endif

--- a/meson/dependencies/meteoIO/meson.build
+++ b/meson/dependencies/meteoIO/meson.build
@@ -1,0 +1,50 @@
+_opt = 'METEOIO'
+_dir = get_option(_opt+'_DIR')
+_libname = _opt.to_lower()
+
+_code = '''
+#include <meteoio/Config.h>
+int main()
+{}
+'''
+
+compiler = meson.get_compiler('cpp')
+
+
+if _dir == ''
+
+    _compiles = compiler.compiles(_code, name:
+                                  _opt+' compile flags check')
+
+    if not _compiles
+       error('\n\nCannot find suitable installation for '+_opt+'. Try to specify the prefix with the option -DMETEOIO_DIR')
+    endif
+    
+    _lib = compiler.find_library(_libname,  required: 'true')
+
+    meteoio = declare_dependency(dependencies:_lib)
+else
+
+    _includedir = include_directories(_dir+'/include')
+    _compiles = compiler.compiles(_code, name:
+                                  _opt+' compile flags check',
+                                  include_directories:_includedir)
+
+    if not _compiles
+       error('\n\nCannot find suitable installation for '+_opt+' in '+_dir)
+    endif
+
+    _libpath = _dir+'/lib'
+    _lib = compiler.find_library('meteoio', dirs:_libpath, required: 'true')
+
+    meteoio = declare_dependency(include_directories: _includedir,
+                                 dependencies:_lib)
+    
+    rpaths = _libpath+':'+rpaths
+endif
+
+
+
+deps += meteoio
+
+

--- a/meson/dependencies/meteoIO/meson.build
+++ b/meson/dependencies/meteoIO/meson.build
@@ -20,7 +20,7 @@ if _dir == ''
        error('\n\nCannot find suitable installation for '+_opt+'. Try to specify the prefix with the option -DMETEOIO_DIR')
     endif
     
-    _lib = compiler.find_library(_libname,  required: 'true')
+    _lib = compiler.find_library(_libname,  required: true)
 
     meteoio = declare_dependency(dependencies:_lib)
 else
@@ -35,7 +35,7 @@ else
     endif
 
     _libpath = _dir+'/lib'
-    _lib = compiler.find_library('meteoio', dirs:_libpath, required: 'true')
+    _lib = compiler.find_library('meteoio', dirs:_libpath, required: true)
 
     meteoio = declare_dependency(include_directories: _includedir,
                                  dependencies:_lib)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,6 +3,9 @@ option('MUTE_GEOTIMER', type: 'boolean', value: false)
 option('MATH_OPTIM', type: 'boolean', value: false)
 option('WITH_OMP', type: 'boolean', value: false, description: 'Enable openMP framework')
 
+option('WITH_METEOIO', type: 'boolean', value: false, description: 'Use MeteoIO library')
+option('METEOIO_DIR', type: 'string', value: '', description: 'Path to prefix of MeteoIO library')
+
 # used to pass additional arguments when running tidy
 # target e.g. '-fix-errors' to apply fixes proposed
 # by the linter

--- a/src/geotop/config.cmake.h.in
+++ b/src/geotop/config.cmake.h.in
@@ -9,5 +9,6 @@
 #cmakedefine MUTE_GEOTIMER
 #cmakedefine MATH_OPTIM
 #cmakedefine WITH_OMP
+#cmakedefine WITH_METEOIO
 
 #endif

--- a/src/geotop/config.meson.h.in
+++ b/src/geotop/config.meson.h.in
@@ -9,4 +9,5 @@
 #mesondefine MUTE_GEOTIMER
 #mesondefine MATH_OPTIM
 #mesondefine WITH_OMP
+#mesondefine WITH_METEOIO
 #endif


### PR DESCRIPTION
@ElisaBortoli,
this is how I would handle meteoio in our build system tools. When you want to use a feature of meteoio you have to remember:
- `#include "config.h" // this is where cmake and meson store the build options`
- use the guards around the code 
```c++
#ifdef WITH_METEOIO
....
#endif
``` 