### PR TITLE
Maintaining "Pi/180." instead of "FromDegToRad"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,13 @@ before_install:
   - cd ..
 
 install:
-  - meson.py -DMUTE_GEOLOG=true -DMUTE_GEOTIMER=true -DWITH_METEOIO=true -DMETEOIO_DIR=$HOME/meteoio meson-build-release
+  - meson.py -DMUTE_GEOLOG=true -DMUTE_GEOTIMER=true meson-build-release
+#  - meson.py -DMUTE_GEOLOG=true -DMUTE_GEOTIMER=true -DWITH_METEOIO=true -DMETEOIO_DIR=$HOME/meteoio meson-build-release
   - cd meson-build-release
   - ninja -j2
 
 script:
-  - meson.py test --suite geotop:small_example --print-errorlogs
+  - meson.py test --print-errorlogs
   #- meson.py test --suite geotop:unit_tests --print-errorlogs
   # - meson.py test --suite geotop:1D --print-errorlogs
   # - travis_wait 90 meson.py test --suite geotop:3D --print-errorlogs

--- a/src/geotop/blowingsnow.cc
+++ b/src/geotop/blowingsnow.cc
@@ -302,8 +302,8 @@ void set_inhomogeneous_fetch(SNOW *snow, METEO *met, LAND *land, PAR *par,
           //find west-east component
           for (c=1; c<=Nc; c++)
             {
-              (*snow->Qtrans_x)(r,c)=fabs((*snow->Qtrans)(r,c)*(-sin((*met->Vdir)(r,c)*GTConst::FromDegToRad)));
-              (*snow->Qsub_x)(r,c)=fabs((*snow->Qsub)(r,c)*(-sin((*met->Vdir)(r,c)*GTConst::FromDegToRad)));
+              (*snow->Qtrans_x)(r,c)=fabs((*snow->Qtrans)(r,c)*(-sin((*met->Vdir)(r,c)*GTConst::Pi/180.)));
+              (*snow->Qsub_x)(r,c)=fabs((*snow->Qsub)(r,c)*(-sin((*met->Vdir)(r,c)*GTConst::Pi/180.)));
             }
 
           //find when there is a wind direction inversion
@@ -322,7 +322,7 @@ void set_inhomogeneous_fetch(SNOW *snow, METEO *met, LAND *land, PAR *par,
                 {
                   c++;
                 }
-              while ( (-sin((*met->Vdir)(r,c)*GTConst::FromDegToRad))*(-sin((*met->Vdir)(r,c0)*GTConst::FromDegToRad))>0 && c<Nc );
+              while ( (-sin((*met->Vdir)(r,c)*GTConst::Pi/180.))*(-sin((*met->Vdir)(r,c0)*GTConst::Pi/180.))>0 && c<Nc );
 
               num_change++;
               c0=c;
@@ -334,7 +334,7 @@ void set_inhomogeneous_fetch(SNOW *snow, METEO *met, LAND *land, PAR *par,
           for (i=1; i<num_change; i++)
             {
               //east wind
-              if ( (-sin((*met->Vdir)(r,(*snow->change_dir_wind)(i))*GTConst::FromDegToRad)) > 0 )
+              if ( (-sin((*met->Vdir)(r,(*snow->change_dir_wind)(i))*GTConst::Pi/180.)) > 0 )
                 {
                   if (par->upwindblowingsnow==1 && (*snow->change_dir_wind)(i)!=1)
                     (*snow->Qtrans_x)(r,(*snow->change_dir_wind)(i))=0.0;
@@ -412,8 +412,8 @@ void set_inhomogeneous_fetch(SNOW *snow, METEO *met, LAND *land, PAR *par,
           //find south-north component
           for (r=1; r<=Nr; r++)
             {
-              (*snow->Qtrans_y)(r,c)=fabs((*snow->Qtrans)(r,c)*(-cos((*met->Vdir)(r,c)*GTConst::FromDegToRad)));
-              (*snow->Qsub_y)(r,c)=fabs((*snow->Qsub)(r,c)*(-cos((*met->Vdir)(r,c)*GTConst::FromDegToRad)));
+              (*snow->Qtrans_y)(r,c)=fabs((*snow->Qtrans)(r,c)*(-cos((*met->Vdir)(r,c)*GTConst::Pi/180.)));
+              (*snow->Qsub_y)(r,c)=fabs((*snow->Qsub)(r,c)*(-cos((*met->Vdir)(r,c)*GTConst::Pi/180.)));
             }
 
           //find when there is a wind direction inversion
@@ -432,7 +432,7 @@ void set_inhomogeneous_fetch(SNOW *snow, METEO *met, LAND *land, PAR *par,
                 {
                   r++;
                 }
-              while ( (-cos((*met->Vdir)(r,c)*GTConst::FromDegToRad))*(-cos((*met->Vdir)(r0,c)*GTConst::FromDegToRad))>0 && r<Nr );
+              while ( (-cos((*met->Vdir)(r,c)*GTConst::Pi/180.))*(-cos((*met->Vdir)(r0,c)*GTConst::Pi/180.))>0 && r<Nr );
 
               num_change++;
               r0=r;
@@ -444,7 +444,7 @@ void set_inhomogeneous_fetch(SNOW *snow, METEO *met, LAND *land, PAR *par,
           for (i=1; i<num_change; i++)
             {
               //south wind
-              if ( (-cos((*met->Vdir)((*snow->change_dir_wind)(i),c)*GTConst::FromDegToRad)) < 0 )
+              if ( (-cos((*met->Vdir)((*snow->change_dir_wind)(i),c)*GTConst::Pi/180.)) < 0 )
                 {
                   if (par->upwindblowingsnow==1 && (*snow->change_dir_wind)(i)!=1)
                     (*snow->Qtrans)((*snow->change_dir_wind)(i),c)=0.0;

--- a/src/geotop/channels.cc
+++ b/src/geotop/channels.cc
@@ -100,7 +100,7 @@ void enumerate_channels(CHANNEL *cnet, Matrix<double> *LC,
     {
         r = (*cnet->r)(i);
         c = (*cnet->c)(i);
-        (*cnet->length)(i) *= ((*UV->U)(1)/cos((*slope)(r,c)*GTConst::FromDegToRad));
+        (*cnet->length)(i) *= ((*UV->U)(1)/cos((*slope)(r,c)*GTConst::Pi/180.));
     }
 
 }

--- a/src/geotop/clouds.cc
+++ b/src/geotop/clouds.cc
@@ -55,7 +55,7 @@ short fill_meteo_data_with_cloudiness(double **meteo, long meteolines,
     {
 
       cloudtrans = (double *)malloc(meteolines*sizeof(double));
-      cloudiness(meteo, meteolines, horizon, horizonlines, lat*GTConst::FromDegToRad, lon*GTConst::FromDegToRad,
+      cloudiness(meteo, meteolines, horizon, horizonlines, lat*GTConst::Pi/180., lon*GTConst::Pi/180.,
                  ST, Z, sky, SWrefl_surr, cloudtrans, ndivday, rotation, Lozone, alpha, beta,
                  albedo);
 
@@ -167,7 +167,7 @@ void cloudiness(double **meteo, long meteolines, double **horizon,
   height_sun = SolarHeight(meteo[n][iJDfrom0], lat, Delta,
                            (lon - ST*GTConst::Pi/12. + Et)/GTConst::omega);
   dir_sun = SolarAzimuth(meteo[n][iJDfrom0], lat, Delta,
-                         (lon - ST*GTConst::Pi/12. + Et)/GTConst::omega) + rotation*GTConst::FromDegToRad;
+                         (lon - ST*GTConst::Pi/12. + Et)/GTConst::omega) + rotation*GTConst::Pi/180.;
   if (dir_sun < 0) dir_sun += 2*GTConst::Pi;
   if (dir_sun > 2*GTConst::Pi) dir_sun -= 2*GTConst::Pi;
 
@@ -348,7 +348,7 @@ void find_sunset(long nist, long *n0, long *n1, double **meteo,
       alpha = SolarHeight(meteo[n][iJDfrom0], lat, Delta,
                           (lon - ST*GTConst::Pi/12. + Et)/GTConst::omega);
       direction = SolarAzimuth(meteo[n][iJDfrom0], lat, Delta,
-                               (lon - ST*GTConst::Pi/12. + Et)/GTConst::omega) + rotation*GTConst::FromDegToRad;
+                               (lon - ST*GTConst::Pi/12. + Et)/GTConst::omega) + rotation*GTConst::Pi/180.;
       if (direction < 0) direction += 2*GTConst::Pi;
       if (direction > 2*GTConst::Pi) direction -= 2*GTConst::Pi;
 

--- a/src/geotop/constants.h
+++ b/src/geotop/constants.h
@@ -72,7 +72,6 @@ namespace GTConst {
     constexpr double Ls = 2834700.00;     /* latent heat of sublimation [J/kg] */
     constexpr double g = 9.81;      /* gravity acceleration [m/s2] */
     constexpr double Pi = 3.14159265358979;
-    constexpr double FromDegToRad = Pi/180; /** conversion from degrees to radians */
     constexpr double tk = 273.15;    /* =0 Deg in Kelvin*/
     constexpr double k_liq = 0.567;  /* thermal conductivity of water [W m^-1 K^-1]*/
     constexpr double k_ice = 2.290;  /* thermal conductivity of water [W m^-1 K^-1]*/

--- a/src/geotop/energy.balance.cc
+++ b/src/geotop/energy.balance.cc
@@ -123,12 +123,12 @@ short EnergyBalance(double Dt, double JD0, double JDb, double JDe,
 
     if (A->P->point_sim != 1)
     {
-        A->E->sun[0] = A->P->latitude*GTConst::FromDegToRad;
-        A->E->sun[2] = (A->P->longitude*GTConst::FromDegToRad - A->P->ST*GTConst::Pi/12. + Et)/GTConst::omega;
+        A->E->sun[0] = A->P->latitude*GTConst::Pi/180.;
+        A->E->sun[2] = (A->P->longitude*GTConst::Pi/180. - A->P->ST*GTConst::Pi/12. + Et)/GTConst::omega;
         A->E->hsun = adaptiveSimpsons2(SolarHeight__, A->E->sun, JDb, JDe, 1.E-6,
                                        20) / (JDe - JDb);
         A->E->dsun = adaptiveSimpsons2(SolarAzimuth__, A->E->sun, JDb, JDe, 1.E-6,
-                                       20) / (JDe - JDb) + A->P->dem_rotation*GTConst::FromDegToRad;
+                                       20) / (JDe - JDb) + A->P->dem_rotation*GTConst::Pi/180.;
         if (A->E->dsun < 0) A->E->dsun += 2*GTConst::Pi;
         if (A->E->dsun > 2*GTConst::Pi) A->E->dsun -= 2*GTConst::Pi;
         A->E->sinhsun = adaptiveSimpsons2(Sinalpha_, A->E->sun, JDb, JDe, 1.E-6,
@@ -298,10 +298,10 @@ short PointEnergyBalance(long i, long r, long c, double Dt, double JDb,
 
     Precpoint=(*A->W->PrecTot)(r,c);
     //define prec as normal (not vertical)
-    Precpoint*=cos((*A->T->slope)(r,c)*GTConst::FromDegToRad);
+    Precpoint*=cos((*A->T->slope)(r,c)*GTConst::Pi/180.);
     //another cosine correction applied for point simulations (due to area proejection)
     if (A->P->point_sim==1 && A->P->flag1D==0)
-        Precpoint*=cos((*A->T->slope)(r,c)*GTConst::FromDegToRad);
+        Precpoint*=cos((*A->T->slope)(r,c)*GTConst::Pi/180.);
 
     Tdirichlet=A->M->var[A->M->nstTs-1][iTs];
     if ((long)Tdirichlet == number_novalue
@@ -488,13 +488,13 @@ short PointEnergyBalance(long i, long r, long c, double Dt, double JDb,
     //calculation of SWin
     if (A->P->point_sim==1)
     {
-        A->E->sun[0] = (*A->T->latitude)(r,c)*GTConst::FromDegToRad;
-        A->E->sun[2] = ((*A->T->longitude)(r,c)*GTConst::FromDegToRad - A->P->ST*GTConst::Pi/12. +
+        A->E->sun[0] = (*A->T->latitude)(r,c)*GTConst::Pi/180.;
+        A->E->sun[2] = ((*A->T->longitude)(r,c)*GTConst::Pi/180. - A->P->ST*GTConst::Pi/12. +
                         Et)/GTConst::omega;
         A->E->hsun = adaptiveSimpsons2(SolarHeight__, A->E->sun, JDb, JDe, 1.E-6,
                                        20) / (JDe - JDb);
         A->E->dsun = adaptiveSimpsons2(SolarAzimuth__, A->E->sun, JDb, JDe, 1.E-6,
-                                       20) / (JDe - JDb) + A->P->dem_rotation*GTConst::FromDegToRad;
+                                       20) / (JDe - JDb) + A->P->dem_rotation*GTConst::Pi/180.;
         if (A->E->dsun < 0) A->E->dsun += 2*GTConst::Pi;
         if (A->E->dsun > 2*GTConst::Pi) A->E->dsun -= 2*GTConst::Pi;
         A->E->sinhsun = adaptiveSimpsons2(Sinalpha_, A->E->sun, JDb, JDe, 1.E-6,
@@ -508,8 +508,8 @@ short PointEnergyBalance(long i, long r, long c, double Dt, double JDb,
     A->E->sun[3] = RHpoint;
     A->E->sun[4] = Tpoint;
     A->E->sun[5] = Ppoint;
-    A->E->sun[6] = (*A->T->slope)(r,c)*GTConst::FromDegToRad;
-    A->E->sun[7] = (*A->T->aspect)(r,c)*GTConst::FromDegToRad;
+    A->E->sun[6] = (*A->T->slope)(r,c)*GTConst::Pi/180.;
+    A->E->sun[7] = (*A->T->aspect)(r,c)*GTConst::Pi/180.;
     if (A->P->albedoSWin != 0) A->E->sun[11] = (avis_b + avis_d + anir_b +
                                                 anir_d)/4.;
 

--- a/src/geotop/input.cc
+++ b/src/geotop/input.cc
@@ -295,7 +295,7 @@ void get_all_input(long  /*argc*/, char * /*argv*/[], TOPO *top, SOIL *sl, LAND 
                 par->total_pixel++;
                 if (par->point_sim != 1)
                 {
-                    par->total_area += ((*UV->U)(1) * (*UV->U)(2))/cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                    par->total_area += ((*UV->U)(1) * (*UV->U)(2))/cos((*top->slope)(r,c)*GTConst::Pi/180.);
                 }
                 else
                 {
@@ -978,12 +978,13 @@ land cover %ld, meteo station %ld\n",
             if ((long)(*IT->init_water_table_depth)(sy) != number_novalue)
             {
                 z = 0.;
-                (*sl->SS->P)(0,i) = -(*IT->init_water_table_depth)(sy)*cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                (*sl->SS->P)(0,i) = -(*IT->init_water_table_depth)(sy) * cos((*top->slope)(r,c)*GTConst::Pi/180.);
+		
                 for (l=1; l<=Nl; l++)
                 {
-                    z += 0.5 * (*sl->pa)(sy,jdz,l)*cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                    z += 0.5 * (*sl->pa)(sy,jdz,l)*cos((*top->slope)(r,c)*GTConst::Pi/180.);
                     (*sl->SS->P)(l,i) = (*sl->SS->P)(0,i) + z;
-                    z += 0.5 * (*sl->pa)(sy,jdz,l)*cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                    z += 0.5 * (*sl->pa)(sy,jdz,l)*cos((*top->slope)(r,c)*GTConst::Pi/180.);
                 }
             }
             else
@@ -1008,12 +1009,12 @@ land cover %ld, meteo station %ld\n",
             sy=(*sl->type)(r,c);
 
             z = 0.;
-            (*sl->SS->P)(0,i) = -(*M)(r,c)*cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+            (*sl->SS->P)(0,i) = -(*M)(r,c)*cos((*top->slope)(r,c)*GTConst::Pi/180.);
             for (l=1; l<=Nl; l++)
             {
-                z += 0.5*(*sl->pa)(sy,jdz,l)*cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                z += 0.5*(*sl->pa)(sy,jdz,l)*cos((*top->slope)(r,c)*GTConst::Pi/180.);
                 (*sl->SS->P)(l,i) = (*sl->SS->P)(0,i) + z;
-                z += 0.5*(*sl->pa)(sy,jdz,l)*cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                z += 0.5*(*sl->pa)(sy,jdz,l)*cos((*top->slope)(r,c)*GTConst::Pi/180.);
             }
         }
     }
@@ -2349,7 +2350,7 @@ but you assigned a value of the glacier depth. The latter will be ignored." << s
 
             if (par->output_vertical_distances == 1)
             {
-                cosslope = cos( std::min<double>(GTConst::max_slope,(*top->slope)(r,c)) * GTConst::FromDegToRad );
+                cosslope = cos( std::min<double>(GTConst::max_slope,(*top->slope)(r,c)) * GTConst::Pi/180. );
             }
             else
             {
@@ -2701,8 +2702,8 @@ to the soil type map");
         write_map(files[fslp], 0, par->format_out, top->slope.get(), UV, number_novalue);
 
     find_min_max(top->slope.get(), (double)number_novalue, &max, &min);
-    geolog << "Slope Min:" << tan(min*GTConst::FromDegToRad) << "(" << min << "deg)"
-           << "Max:" << tan(max*GTConst::FromDegToRad) << "(" << max << "deg)" << std::endl;
+    geolog << "Slope Min:" << tan(min*GTConst::Pi/180.) << "(" << min << "deg)"
+           << "Max:" << tan(max*GTConst::Pi/180.) << "(" << max << "deg)" << std::endl;
 
     /**************************************************************************************************/
     // ASPECT
@@ -3116,8 +3117,8 @@ void read_optionsfile_point(PAR *par, TOPO *top, LAND *land, SOIL *sl, TIMES * /
     if (read_sl==1)
     {
         find_min_max(P.get(), (double)number_novalue, &max, &min);
-        geolog << "Slope Min:" << tan(min*GTConst::FromDegToRad) << "(" << min << "deg)"
-               << "Max:" << tan(max*GTConst::FromDegToRad) << "(" << max << "deg)" << std::endl;
+        geolog << "Slope Min:" << tan(min*GTConst::Pi/180.) << "(" << min << "deg)"
+               << "Max:" << tan(max*GTConst::Pi/180.) << "(" << max << "deg)" << std::endl;
 
         for (i=1; i<=par->chkpt->nrh; i++)
         {
@@ -3788,7 +3789,7 @@ std::unique_ptr<Tensor<double>> find_Z_of_any_layer(Matrix<double> *Zsurface, Ma
         {
             if ((long)(*LC)(r,c)!=number_novalue)
             {
-                cosine = cos((*slope)(r,c)*GTConst::FromDegToRad);
+                cosine = cos((*slope)(r,c)*GTConst::Pi/180.);
                 sy=(*sl->type)(r,c);
 
                 if (point!=1)

--- a/src/geotop/meteo.cc
+++ b/src/geotop/meteo.cc
@@ -100,8 +100,8 @@ void meteo_distr(long *line, long lineLR, METEO *met, WATER *wat, TOPO *top,
         {
           for (c=1; c<=Nc; c++)
             {
-              (*wat->Pnet)(r,c) = par->raincorrfact*(*wat->PrecTot)(r,c)*((JDend-JDbeg)*24.)*cos((*top->slope)(r,c)*GTConst::FromDegToRad); //from [mm/h] to [mm]
-              if (par->point_sim==1) (*wat->Pnet)(r,c) *= cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+              (*wat->Pnet)(r,c) = par->raincorrfact*(*wat->PrecTot)(r,c)*((JDend-JDbeg)*24.)*cos((*top->slope)(r,c)*GTConst::Pi/180.); //from [mm/h] to [mm]
+              if (par->point_sim==1) (*wat->Pnet)(r,c) *= cos((*top->slope)(r,c)*GTConst::Pi/180.);
             }
         }
     }

--- a/src/geotop/output.cc
+++ b/src/geotop/output.cc
@@ -153,7 +153,7 @@ void write_output(TIMES *times, WATER *wat, CHANNEL *cnet, PAR *par,
             {
                 r = (*cnet->r)(l);
                 c = (*cnet->c)(l);
-                Vchannel += 1.E-3 * std::max<double>((*cnet->SS->P)(0,l), 0.) / cos((*top->slope)(r,c)*GTConst::FromDegToRad) *
+                Vchannel += 1.E-3 * std::max<double>((*cnet->SS->P)(0,l), 0.) / cos((*top->slope)(r,c)*GTConst::Pi/180.) *
                             (*UV->U)(1) * par->w_dx * (*cnet->length)(l);
                 Vsub += (*cnet->Vsub)(l);
                 Vsup += (*cnet->Vsup)(l);
@@ -273,7 +273,7 @@ void write_output(TIMES *times, WATER *wat, CHANNEL *cnet, PAR *par,
 
                     if (par->output_vertical_distances == 1)
                     {
-                        cosslope = cos( std::min<double>(GTConst::max_slope, (*top->slope)(r,c)) * GTConst::FromDegToRad );
+                        cosslope = cos( std::min<double>(GTConst::max_slope, (*top->slope)(r,c)) * GTConst::Pi/180. );
                     }
                     else
                     {
@@ -1333,7 +1333,7 @@ void write_output(TIMES *times, WATER *wat, CHANNEL *cnet, PAR *par,
             {
                 r = (*top->rc_cont)(i,1);
                 c = (*top->rc_cont)(i,2);
-                (*V)(i) = std::max<double>(0, (*sl->SS->P)(0,i)) / cos((*top->slope)(r,c) * GTConst::FromDegToRad);
+                (*V)(i) = std::max<double>(0, (*sl->SS->P)(0,i)) / cos((*top->slope)(r,c) * GTConst::Pi/180.);
             }
             temp1 = join_strings(files[fhsupland], s2);
             write_map_vector(temp1, 0, par->format_out, V.get(), UV, number_novalue,
@@ -1349,7 +1349,7 @@ void write_output(TIMES *times, WATER *wat, CHANNEL *cnet, PAR *par,
                 c = (*top->rc_cont)(i,2);
                 if ((*cnet->ch)(r,c)!=0)
                 {
-                    (*V)(i) = (*cnet->SS->P)(0,(*cnet->ch)(r,c)) / cos((*top->slope)(r,c) *GTConst::FromDegToRad);
+                    (*V)(i) = (*cnet->SS->P)(0,(*cnet->ch)(r,c)) / cos((*top->slope)(r,c) *GTConst::Pi/180.);
                 }
                 else
                 {
@@ -4764,7 +4764,7 @@ void write_tensorseries_soil(long lmin, char *suf, char *filename, short type,
 
         for (i=1; i<=npoints; i++)
         {
-            if (vertical == 1) cosslope = cos( std::min<double>(GTConst::max_slope, (*slope)((*RC)(i,1),(*RC)(i,2))) * GTConst::FromDegToRad );
+            if (vertical == 1) cosslope = cos( std::min<double>(GTConst::max_slope, (*slope)((*RC)(i,1),(*RC)(i,2))) * GTConst::Pi/180. );
             (*V)(i) = interpolate_soil2(lmin, (*n)(l)*cosslope, Nl, std::forward<RowView<double>>(dz), T, i);
         }
 
@@ -4933,9 +4933,9 @@ void fill_output_vectors(double Dt, double W, ENERGY *egy, SNOW *snow,
                 || strcmp(files[pVdir], string_novalue) != 0)
             {
                 (*met->Vxplot)(j) -= W * (*met->Vgrid)((*top->rc_cont)(j,1),(*top->rc_cont)(j,2))
-                                     * sin( (*met->Vdir)( (*top->rc_cont)(j,1), (*top->rc_cont)(j,2) )*GTConst::FromDegToRad );
+                                     * sin( (*met->Vdir)( (*top->rc_cont)(j,1), (*top->rc_cont)(j,2) )*GTConst::Pi/180. );
                 (*met->Vyplot)(j) -= W * (*met->Vgrid)((*top->rc_cont)(j,1),(*top->rc_cont)(j,2))
-                                     * cos( (*met->Vdir)( (*top->rc_cont)(j,1), (*top->rc_cont)(j,2) )*GTConst::FromDegToRad );
+                                     * cos( (*met->Vdir)( (*top->rc_cont)(j,1), (*top->rc_cont)(j,2) )*GTConst::Pi/180. );
             }
 
         }

--- a/src/geotop/radiation.cc
+++ b/src/geotop/radiation.cc
@@ -737,8 +737,8 @@ double find_tau_cloud_station(double JDbeg, double JDend, long i, METEO *met,
   T=met->var[i-1][iT];
   if ((long)T == number_novalue || (long)T == number_absent) T=0.0;
 
-  c = cloud_transmittance(JDbeg, JDend, (*met->st->lat)(i)*GTConst::FromDegToRad, Delta,
-                          ((*met->st->lon)(i)*GTConst::FromDegToRad - ST*GTConst::Pi/12. + Et)/GTConst::omega, RH,
+  c = cloud_transmittance(JDbeg, JDend, (*met->st->lat)(i)*GTConst::Pi/180., Delta,
+                          ((*met->st->lon)(i)*GTConst::Pi/180. - ST*GTConst::Pi/12. + Et)/GTConst::omega, RH,
                           T, P, met->var[i-1][iSWd], met->var[i-1][iSWb], met->var[i-1][iSW], E0,
                           (*met->st->sky)(i), SWrefl_surr,
                           Lozone, alpha, beta, albedo);

--- a/src/geotop/snow.cc
+++ b/src/geotop/snow.cc
@@ -123,7 +123,7 @@ void snow_compactation(double Dt, long r, long c, long l, STATEVAR_3D *snow,
     {
       load+=((*snow->w_ice)(m,r,c) + (*snow->w_liq)(m,r,c));
     }
-    load*=fabs(cos(slope*GTConst::FromDegToRad));
+    load*=fabs(cos(slope*GTConst::Pi/180.));
     eta=eta0*exp(c4*(GTConst::Tfreezing-(*snow->T)(l,r,c))+c5*(GTConst::rho_i*theta_i));
     CR2=-load/eta;
 

--- a/src/geotop/water.balance.cc
+++ b/src/geotop/water.balance.cc
@@ -112,9 +112,9 @@ short water_balance(double Dt, double JD0, double JD1, double JD2,
           r=adt->T->lrc_cont->co[j][2];
           c=adt->T->lrc_cont->co[j][3];
           sy=(*adt->S->type)(r,c);
-          area=ds*ds/cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+          area=ds*ds/cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
           if(l==0){
-            m1 += area * 1.E-3*std::max<double>(0.0, L->P->co[l][adt->T->j_cont[r][c]]) / cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+            m1 += area * 1.E-3*std::max<double>(0.0, L->P->co[l][adt->T->j_cont[r][c]]) / cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
           }else {
             dz = (*adt->S->pa)(sy,jdz,l);
             m1 += area*1.E-3*dz * theta_from_psi(L->P->co[l][adt->T->j_cont[r][c]], 0, l, adt->S->pa->matrix(sy), GTConst::PsiMin);
@@ -138,9 +138,9 @@ short water_balance(double Dt, double JD0, double JD1, double JD2,
           r=adt->T->lrc_cont->co[j][2];
           c=adt->T->lrc_cont->co[j][3];
           sy=(*adt->S->type)(r,c);
-          area=ds*ds/cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+          area=ds*ds/cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
           if(l==0){
-            m2 += area * 1.E-3*std::max<double>(0.0, L->P->co[l][adt->T->j_cont[r][c]]) / cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+            m2 += area * 1.E-3*std::max<double>(0.0, L->P->co[l][adt->T->j_cont[r][c]]) / cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
           }else {
             dz = (*adt->S->pa)(sy,jdz,l);
             m2 += area*1.E-3*dz * theta_from_psi(L->P->co[l][adt->T->j_cont[r][c]], 0, l, adt->S->pa->matrix(sy), GTConst::PsiMin);
@@ -181,7 +181,7 @@ short water_balance(double Dt, double JD0, double JD1, double JD2,
             }
             if ( (*L->P)(0,j) > 0 )
                 (*L->P)(0,j) = std::min<double>( (*L->P)(0,j),
-                                                 std::max<double>(0.,-(*adt->T->BC_DepthFreeSurface)(j))*cos((*adt->T->slope)(1,j)*GTConst::FromDegToRad) );
+                                                 std::max<double>(0.,-(*adt->T->BC_DepthFreeSurface)(j))*cos((*adt->T->slope)(1,j)*GTConst::Pi/180.) );
         }
         end=clock();
         t_sub += (end-start)/(double)CLOCKS_PER_SEC;
@@ -270,7 +270,7 @@ short Richards3D(double Dt, SOIL_STATE *L, SOIL_STATE *C, ALLDATA *adt, double *
             /** precipitation */
             if (l == 0 && (*adt->W->Pnet)(r,c) > 0)
             {
-                *Total_Pnet = *Total_Pnet + ((*adt->W->Pnet)(r,c)/cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad))
+                *Total_Pnet = *Total_Pnet + ((*adt->W->Pnet)(r,c)/cos((*adt->T->slope)(r,c)*GTConst::Pi/180.))
                                             / (double)adt->P->total_pixel;
             }
 
@@ -278,7 +278,7 @@ short Richards3D(double Dt, SOIL_STATE *L, SOIL_STATE *C, ALLDATA *adt, double *
             if ((*adt->W->Pnet)(r,c) > 0 && l == 0)
             {
                 (*adt->W->H1)(i) = std::max<double>(0.,  (*L->P)(l,j))
-                                   + ((*adt->W->Pnet)(r,c)/cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad))
+                                   + ((*adt->W->Pnet)(r,c)/cos((*adt->T->slope)(r,c)*GTConst::Pi/180.))
                                    + (*adt->T->Z)(l,r,c);
             }
             else
@@ -299,7 +299,7 @@ short Richards3D(double Dt, SOIL_STATE *L, SOIL_STATE *C, ALLDATA *adt, double *
             if ((*adt->W->Pnet)(r,c) > 0 && l == 0)
             {
                 (*adt->W->H1)(i) = std::max<double>( 0., (*C->P)(l,ch))
-                                   + ( (*adt->W->Pnet)(r,c)/cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad) )
+                                   + ( (*adt->W->Pnet)(r,c)/cos((*adt->T->slope)(r,c)*GTConst::Pi/180.) )
                                    + ( (*adt->T->Z)(l,r,c) - adt->P->depr_channel );
             }
             else
@@ -508,7 +508,7 @@ short Richards3D(double Dt, SOIL_STATE *L, SOIL_STATE *C, ALLDATA *adt, double *
             /** volume lost at the bottom */
             if (l==Nl)
             {
-                area = ds*ds/cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+                area = ds*ds/cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
                 if (ch>0) area -= (*adt->C->length)(ch) * adt->P->w_dx *
                                   ds; //area of the pixel[m2]
                 *Vbottom = *Vbottom + area * (*adt->W->Kbottom)(r,c) * 1.E-3 * Dt;
@@ -525,7 +525,7 @@ short Richards3D(double Dt, SOIL_STATE *L, SOIL_STATE *C, ALLDATA *adt, double *
                     {
                         /* The depth of the free surface is multiplied by cosine since Z's are the layer depths in vertical direction */
                         if ( (*adt->T->Z)(0,r,c) - (*adt->T->Z)(l,r,c) <=
-                             ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad)
+                             ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::Pi/180.)
                              && (*adt->W->H1)(i) - (*adt->T->Z)(l,r,c) > 0 )
                         {
 
@@ -555,7 +555,7 @@ short Richards3D(double Dt, SOIL_STATE *L, SOIL_STATE *C, ALLDATA *adt, double *
                     {
 
                         if ( (*adt->T->Z)(0,r,c) - (*adt->T->Z)(l,r,c) <=
-                             ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad) )
+                             ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::Pi/180.) )
                         {
 
                             dz = (*adt->S->pa)(sy,jdz,l); /// [mm]
@@ -592,7 +592,7 @@ short Richards3D(double Dt, SOIL_STATE *L, SOIL_STATE *C, ALLDATA *adt, double *
             if (l==0)
             {
                 /** hold and hnew are normal */
-                hold = std::max<double>(0., (*C->P)(l,ch)) / cos((*adt->T->slope)(r,c) * GTConst::FromDegToRad);
+                hold = std::max<double>(0., (*C->P)(l,ch)) / cos((*adt->T->slope)(r,c) * GTConst::Pi/180.);
             }
 
             /** depr channel is defined vertical */
@@ -610,7 +610,7 @@ short Richards3D(double Dt, SOIL_STATE *L, SOIL_STATE *C, ALLDATA *adt, double *
             if (l==0)
             {
                 /** hold and hnew are normal */
-                hnew = std::max<double>(0., (*C->P)(l,ch)) / cos((*adt->T->slope)(r,c) * GTConst::FromDegToRad);
+                hnew = std::max<double>(0., (*C->P)(l,ch)) / cos((*adt->T->slope)(r,c) * GTConst::Pi/180.);
                 (*Vsub)(ch) += 1.E-3 * ( hnew - hold ) * (*adt->C->length)(ch) * adt->P->w_dx * ds;
             }
 
@@ -665,14 +665,14 @@ short Richards1D(long c, double Dt, SOIL_STATE *L, ALLDATA *adt, double *loss, d
         if (l == 0 && (*adt->W->Pnet)(r,c) > 0)
         {
             *Total_Pnet = *Total_Pnet +
-                          ((*adt->W->Pnet)(r,c)/cos(std::min<double>(GTConst::max_slope, (*adt->T->slope)(r,c))*GTConst::FromDegToRad)) / (double)adt->P->total_pixel;
+                          ((*adt->W->Pnet)(r,c)/cos(std::min<double>(GTConst::max_slope, (*adt->T->slope)(r,c))*GTConst::Pi/180.)) / (double)adt->P->total_pixel;
         }
 
         /** solution guess */
         if ((*adt->W->Pnet)(r,c) > 0 && l == 0)
         {
             (*adt->W->H1)(i) = std::max<double>(0., (*L->P)(l,c))
-                               + ((*adt->W->Pnet)(r,c)/cos(std::min<double>(GTConst::max_slope,(*adt->T->slope)(r,c))*GTConst::FromDegToRad))
+                               + ((*adt->W->Pnet)(r,c)/cos(std::min<double>(GTConst::max_slope,(*adt->T->slope)(r,c))*GTConst::Pi/180.))
                                + (*adt->T->Z)(l,r,c);
         }
         else
@@ -889,7 +889,7 @@ short Richards1D(long c, double Dt, SOIL_STATE *L, ALLDATA *adt, double *loss, d
             if ((*adt->T->pixel_type)(r,c) == 1)
             {
                 if ( (*adt->T->Z)(0,r,c) - (*adt->T->Z)(l,r,c) <=
-                     ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad)
+                     ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::Pi/180.)
                      && (*adt->W->H1)(i) - (*adt->T->Z)(l,r,c) > 0 )
                 {
                     dz = (*adt->S->pa)(sy,jdz,l);//[mm]
@@ -965,7 +965,7 @@ int find_matrix_K_3D(double  /*Dt*/, SOIL_STATE *SL, SOIL_STATE *SC,
             sy=(*adt->S->type)(r,c);
 
             ch=(*adt->C->ch)(r,c);
-            area=ds*ds/cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+            area=ds*ds/cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
             if (ch>0) area-=(*adt->C->length)(ch) * adt->P->w_dx *
                             ds; //area of the pixel[m2]
 
@@ -1207,12 +1207,12 @@ int find_matrix_K_3D(double  /*Dt*/, SOIL_STATE *SL, SOIL_STATE *SC,
                         if ((*H)(I) > (*H)(i))
                         {
                             kn = (*adt->L->ty)((long)(*adt->L->LC)(R,C),jcm);
-                            dz = std::max<double>(0., (*H)(I) - (*adt->T->Z)(l,R,C)) / cos((*adt->T->slope)(R,C)*GTConst::FromDegToRad);
+                            dz = std::max<double>(0., (*H)(I) - (*adt->T->Z)(l,R,C)) / cos((*adt->T->slope)(R,C)*GTConst::Pi/180.);
                         }
                         else
                         {
                             kn = (*adt->L->ty)((long)(*adt->L->LC)(R,C),jcm);
-                            dz = std::max<double>(0., (*H)(i) - (*adt->T->Z)(l,r,c)) / cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+                            dz = std::max<double>(0., (*H)(i) - (*adt->T->Z)(l,r,c)) / cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
                         }
 
                         if (dz < adt->P->thres_hsup_1) kn = 0.;
@@ -1267,12 +1267,12 @@ int find_matrix_K_3D(double  /*Dt*/, SOIL_STATE *SL, SOIL_STATE *SC,
                         if ((*H)(I) > (*H)(i))
                         {
                             kn = (*adt->L->ty)((long)(*adt->L->LC)(R,C),jcm);
-                            dz = std::max<double>(0., (*H)(I) - (*adt->T->Z)(l,R,C)) / cos((*adt->T->slope)(R,C)*GTConst::FromDegToRad);
+                            dz = std::max<double>(0., (*H)(I) - (*adt->T->Z)(l,R,C)) / cos((*adt->T->slope)(R,C)*GTConst::Pi/180.);
                         }
                         else
                         {
                             kn = (*adt->L->ty)((long)(*adt->L->LC)(R,C),jcm);
-                            dz = std::max<double>(0., (*H)(i) - (*adt->T->Z)(l,r,c)) / cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+                            dz = std::max<double>(0., (*H)(i) - (*adt->T->Z)(l,r,c)) / cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
                         }
 
                         if (dz < adt->P->thres_hsup_1) kn = 0.;
@@ -1328,12 +1328,12 @@ int find_matrix_K_3D(double  /*Dt*/, SOIL_STATE *SL, SOIL_STATE *SC,
                         if ((*H)(I) > (*H)(i))
                         {
                             kn = (*adt->L->ty)((long)(*adt->L->LC)(R,C),jcm);
-                            dz = std::max<double>(0., (*H)(I) - (*adt->T->Z)(l,R,C)) / cos((*adt->T->slope)(R,C)*GTConst::FromDegToRad);
+                            dz = std::max<double>(0., (*H)(I) - (*adt->T->Z)(l,R,C)) / cos((*adt->T->slope)(R,C)*GTConst::Pi/180.);
                         }
                         else
                         {
                             kn = (*adt->L->ty)((long)(*adt->L->LC)(R,C),jcm);
-                            dz = std::max<double>(0., (*H)(i) - (*adt->T->Z)(l,r,c)) / cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+                            dz = std::max<double>(0., (*H)(i) - (*adt->T->Z)(l,r,c)) / cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
                         }
 
                         if (dz < adt->P->thres_hsup_1) kn = 0.;
@@ -1388,12 +1388,12 @@ int find_matrix_K_3D(double  /*Dt*/, SOIL_STATE *SL, SOIL_STATE *SC,
                         if ((*H)(I) > (*H)(i))
                         {
                             kn = (*adt->L->ty)((long)(*adt->L->LC)(R,C),jcm);
-                            dz = std::max<double>(0., (*H)(I) - (*adt->T->Z)(l,R,C)) / cos((*adt->T->slope)(R,C)*GTConst::FromDegToRad);
+                            dz = std::max<double>(0., (*H)(I) - (*adt->T->Z)(l,R,C)) / cos((*adt->T->slope)(R,C)*GTConst::Pi/180.);
                         }
                         else
                         {
                             kn = (*adt->L->ty)((long)(*adt->L->LC)(R,C),jcm);
-                            dz = std::max<double>(0., (*H)(i) - (*adt->T->Z)(l,r,c)) / cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+                            dz = std::max<double>(0., (*H)(i) - (*adt->T->Z)(l,r,c)) / cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
                         }
 
                         if (dz < adt->P->thres_hsup_1) kn = 0.;
@@ -1594,7 +1594,7 @@ int find_dfdH_3D(double Dt, Vector<double> *df, ALLDATA *adt, SOIL_STATE *L,
             sy = (*adt->S->type)(r,c);
             bc = (*adt->T->BC_counter)(r,c);
             ch = (*adt->C->ch)(r,c);
-            area = ds*ds/cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+            area = ds*ds/cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
             if (ch>0)
                 area-= (*adt->C->length)(ch) * adt->P->w_dx * ds; //area of the pixel[m2]
             psi1 = (*H)(i) - (*adt->T->Z)(l,r,c);
@@ -1617,7 +1617,7 @@ int find_dfdH_3D(double Dt, Vector<double> *df, ALLDATA *adt, SOIL_STATE *L,
         /** hydraulic capacity (diagonal term) = (dV/dH)/(Ah*Dt) */
         if (l==0)
         {
-            if (psi1>0) (*df)(i) += ( area / cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad) ) / Dt;
+            if (psi1>0) (*df)(i) += ( area / cos((*adt->T->slope)(r,c)*GTConst::Pi/180.) ) / Dt;
 
         }
         else
@@ -1637,7 +1637,7 @@ int find_dfdH_3D(double Dt, Vector<double> *df, ALLDATA *adt, SOIL_STATE *L,
                 if ((*adt->T->pixel_type)(r,c) == 1 || (*adt->T->pixel_type)(r,c) == 11)
                 {
                     if ( (*adt->T->Z)(0,r,c) - (*adt->T->Z)(l,r,c) <=
-                         ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad)
+                         ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::Pi/180.)
                          && (*H)(i) - (*adt->T->Z)(l,r,c) > 0 )
                     {
                         if ((long)(*adt->L->LC)(r+1,c)==number_novalue
@@ -1690,7 +1690,7 @@ int find_dfdH_1D(long c, double Dt, SOIL_STATE *L, Vector<double> *df,
         /** hydraulic capacity (diagonal term) = (dV/dH)/(Ah*Dt) */
         if (l==0)
         {
-            if (psi1>0) (*df)(i) += ( area / cos( std::min<double>(GTConst::max_slope, (*adt->T->slope)(r,c))*GTConst::FromDegToRad) ) / Dt;
+            if (psi1>0) (*df)(i) += ( area / cos( std::min<double>(GTConst::max_slope, (*adt->T->slope)(r,c))*GTConst::Pi/180.) ) / Dt;
         }
         else
         {
@@ -1708,7 +1708,7 @@ int find_dfdH_1D(long c, double Dt, SOIL_STATE *L, Vector<double> *df,
             if ((*adt->T->pixel_type)(r,c) == 1)
             {
                 if ( (*adt->T->Z)(0,r,c) - (*adt->T->Z)(l,r,c) <=
-                     ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad)
+                     ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::Pi/180.)
                      && (*H)(i) - (*adt->T->Z)(l,r,c) > 0 )
                 {
                     dz = (*adt->S->pa)(sy,jdz,l);//[mm]
@@ -1753,7 +1753,7 @@ int find_f_3D(double Dt, Vector<double> *f, ALLDATA *adt, SOIL_STATE *L,
             sy = (*adt->S->type)(r,c);
             bc = (*adt->T->BC_counter)(r,c);
             ch = (*adt->C->ch)(r,c);
-            area = ds*ds/cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+            area = ds*ds/cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
 
             if (ch>0)
                 area -= (*adt->C->length)(ch) * adt->P->w_dx * ds; //area of the pixel[m2]
@@ -1784,8 +1784,8 @@ int find_f_3D(double Dt, Vector<double> *f, ALLDATA *adt, SOIL_STATE *L,
         /** hydraulic capacity (diagonal term) */
         if (l==0)
         {
-            V1 = area * std::max<double>(0.0, psi1) / cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
-            V0 = area * std::max<double>(0.0, psi0) / cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad);
+            V1 = area * std::max<double>(0.0, psi1) / cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
+            V0 = area * std::max<double>(0.0, psi0) / cos((*adt->T->slope)(r,c)*GTConst::Pi/180.);
         }
         else
         {
@@ -1818,7 +1818,7 @@ int find_f_3D(double Dt, Vector<double> *f, ALLDATA *adt, SOIL_STATE *L,
                 if ((*adt->T->pixel_type)(r,c) == 1 || (*adt->T->pixel_type)(r,c) == 11)
                 {
                     if ( (*adt->T->Z)(0,r,c) - (*adt->T->Z)(l,r,c) <=
-                         ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad)
+                         ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::Pi/180.)
                          && (*H)(i) - (*adt->T->Z)(l,r,c) > 0 )
                     {
                         if ((long)(*adt->L->LC)(r+1,c)==number_novalue
@@ -1843,7 +1843,7 @@ int find_f_3D(double Dt, Vector<double> *f, ALLDATA *adt, SOIL_STATE *L,
                          || (*adt->T->pixel_type)(r,c) == 12)
                 {
                     if ( (*adt->T->Z)(0,r,c) - (*adt->T->Z)(l,r,c) <=
-                         ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad) )
+                         ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::Pi/180.) )
                     {
                         if ((long)(*adt->L->LC)(r+1,c)==number_novalue
                             || (long)(*adt->L->LC)(r-1,c)==number_novalue)
@@ -1913,9 +1913,9 @@ int find_f_1D(long c, double Dt, SOIL_STATE *L, Vector<double> *f, ALLDATA *adt,
         if (l==0)
         {
             V1 = area * std::max<double>(0.0, psi1) / cos( std::min<double>(GTConst::max_slope,
-                                                                            (*adt->T->slope)(r,c))*GTConst::FromDegToRad);
+                                                                            (*adt->T->slope)(r,c))*GTConst::Pi/180.);
             V0 = area * std::max<double>(0.0, psi0) / cos( std::min<double>(GTConst::max_slope,
-                                                                            (*adt->T->slope)(r,c))*GTConst::FromDegToRad);
+                                                                            (*adt->T->slope)(r,c))*GTConst::Pi/180.);
 
         }
         else
@@ -1941,7 +1941,7 @@ int find_f_1D(long c, double Dt, SOIL_STATE *L, Vector<double> *f, ALLDATA *adt,
             if ((*adt->T->pixel_type)(r,c) == 1)
             {
                 if ( (*adt->T->Z)(0,r,c) - (*adt->T->Z)(l,r,c) <=
-                     ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::FromDegToRad)
+                     ((*adt->T->BC_DepthFreeSurface)(bc))*cos((*adt->T->slope)(r,c)*GTConst::Pi/180.)
                      && (*H)(i) - (*adt->T->Z)(l,r,c) > 0 )
                 {
                     dz = (*adt->S->pa)(sy,jdz,l);//[mm]
@@ -1988,7 +1988,7 @@ void find_dt_max(short DD, double Courant, RowView<double> &&h, LAND *land, TOPO
         r = (*top->rc_cont)(j,1);
         c = (*top->rc_cont)(j,2);
 
-        H =  std::max<double>(0.0, h(j)) / cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+        H =  std::max<double>(0.0, h(j)) / cos((*top->slope)(r,c)*GTConst::Pi/180.);
         /** h[i] is the pressure at the surface, H is the depth of water normal to the surface */
 
         if (H > par->min_hsup_land)
@@ -2004,7 +2004,7 @@ void find_dt_max(short DD, double Courant, RowView<double> &&h, LAND *land, TOPO
             }
 
             area = ds*ds;
-            area /= cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+            area /= cos((*top->slope)(r,c)*GTConst::Pi/180.);
             ch = (*cnet->ch)(r,c);
 
             if (ch>0)
@@ -2055,9 +2055,9 @@ void supflow(short DDland, short DDch, double Dt, double t, RowView<double> &&h,
     {
         r = (*top->rc_cont)(j,1);
         c = (*top->rc_cont)(j,2);
-        H = std::max<double>(0., h(j)) / cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+        H = std::max<double>(0., h(j)) / cos((*top->slope)(r,c)*GTConst::Pi/180.);
         area = ds*ds;
-        area /= cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+        area /= cos((*top->slope)(r,c)*GTConst::Pi/180.);
         m1 += H*1.E-3*area;
     }
 
@@ -2081,7 +2081,7 @@ void supflow(short DDland, short DDch, double Dt, double t, RowView<double> &&h,
             r = (*top->rc_cont)(j,1);
             c = (*top->rc_cont)(j,2);
 
-            H = std::max<double>(0., h(j)) / cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+            H = std::max<double>(0., h(j)) / cos((*top->slope)(r,c)*GTConst::Pi/180.);
 
             dV[j] = 0.0;
 
@@ -2089,7 +2089,7 @@ void supflow(short DDland, short DDch, double Dt, double t, RowView<double> &&h,
             {
 
                 area = ds*ds;
-                area /= cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                area /= cos((*top->slope)(r,c)*GTConst::Pi/180.);
                 ch = (*cnet->ch)(r,c);
                 if (ch>0)
                     area -= (*cnet->length)(ch) * par->w_dx *
@@ -2137,24 +2137,24 @@ void supflow(short DDland, short DDch, double Dt, double t, RowView<double> &&h,
             c = (*top->rc_cont)(j,2);
 
             area = ds*ds;
-            area /= cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+            area /= cos((*top->slope)(r,c)*GTConst::Pi/180.);
             ch = (*cnet->ch)(r,c);
             if (ch>0)
                 area -= (*cnet->length)(ch) * par->w_dx *
                         ds; /** area of the pixel[m2] */
 
-            h(j) -= (1.E3 * dV[j]/area) * cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+            h(j) -= (1.E3 * dV[j]/area) * cos((*top->slope)(r,c)*GTConst::Pi/180.);
 
             if ((*top->BC_counter)(r,c) > 0 && (*top->pixel_type)(r,c) == -1)
             {
                 if (h(j) > 0)
                 {
-                    h(j) += (1.E3*met->qinv[1]*ds*Dt/area) * cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                    h(j) += (1.E3*met->qinv[1]*ds*Dt/area) * cos((*top->slope)(r,c)*GTConst::Pi/180.);
                 }
                 else
                 {
                     if ( met->qinv[1]*ds > 0)
-                        h(j) = (1.E3*met->qinv[1]*ds*Dt/area) * cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                        h(j) = (1.E3*met->qinv[1]*ds*Dt/area) * cos((*top->slope)(r,c)*GTConst::Pi/180.);
                 }
             }
 
@@ -2167,19 +2167,19 @@ void supflow(short DDland, short DDch, double Dt, double t, RowView<double> &&h,
                     C = (*top->rc_cont)((*top->Jdown)(j,d),2);
 
                     area = ds*ds;
-                    area /= cos((*top->slope)(R,C)*GTConst::FromDegToRad);
+                    area /= cos((*top->slope)(R,C)*GTConst::Pi/180.);
                     ch = (*cnet->ch)(R,C);
                     if (ch>0) area -= (*cnet->length)(ch) * par->w_dx *
                                       ds; /** area of the pixel[m2] */
 
                     if (h((*top->Jdown)(j,d))>0)
                     {
-                        h((*top->Jdown)(j,d)) += (1.E3 * dV[j]*(*top->Qdown)(j,d)/area) * cos( (*top->slope)(R,C)*GTConst::FromDegToRad);
+                        h((*top->Jdown)(j,d)) += (1.E3 * dV[j]*(*top->Qdown)(j,d)/area) * cos( (*top->slope)(R,C)*GTConst::Pi/180.);
                     }
                     else
                     {
                         if ( dV[j]*(*top->Qdown)(j,d) > 0)
-                            h((*top->Jdown)(j,d)) = (1.E3 * dV[j]*(*top->Qdown)(j,d)/area) * cos((*top->slope)(R,C)*GTConst::FromDegToRad);
+                            h((*top->Jdown)(j,d)) = (1.E3 * dV[j]*(*top->Qdown)(j,d)/area) * cos((*top->slope)(R,C)*GTConst::Pi/180.);
                     }
 
                 }
@@ -2199,9 +2199,9 @@ void supflow(short DDland, short DDch, double Dt, double t, RowView<double> &&h,
     {
         r = (*top->rc_cont)(j,1);
         c = (*top->rc_cont)(j,2);
-        H = std::max<double>(0., h(j)) / cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+        H = std::max<double>(0., h(j)) / cos((*top->slope)(r,c)*GTConst::Pi/180.);
         area = ds*ds;
-        area /= cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+        area /= cos((*top->slope)(r,c)*GTConst::Pi/180.);
         m2 += H*1.E-3*area;
     }
 
@@ -2232,12 +2232,12 @@ void find_dt_max_chla(double Courant, RowView<double> &&h, RowView<double> &&hch
         c = (*cnet->c)(ch);
 
         H = std::max<double>(0.0, h(ch)) / cos(
-                (*top->slope)(r,c)*GTConst::FromDegToRad);
+                (*top->slope)(r,c)*GTConst::Pi/180.);
         /** h(i) is the pressure at the surface, H is the depth of water normal to the surface */
-        area = ds*ds/cos((*top->slope)(r,c)*GTConst::FromDegToRad) - (*cnet->length)(ch) * par->w_dx * ds;
+        area = ds*ds/cos((*top->slope)(r,c)*GTConst::Pi/180.) - (*cnet->length)(ch) * par->w_dx * ds;
 
-        Hch = std::max<double>(0., hch(ch) ) / cos((*top->slope)(r,c)*GTConst::FromDegToRad)
-              - par->depr_channel * cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+        Hch = std::max<double>(0., hch(ch) ) / cos((*top->slope)(r,c)*GTConst::Pi/180.)
+              - par->depr_channel * cos((*top->slope)(r,c)*GTConst::Pi/180.);
         areach = (*cnet->length)(ch) * par->w_dx * ds;
 
         if (H > par->min_hsup_land)
@@ -2329,11 +2329,11 @@ void supflow_chla(double Dt, double t, RowView<double> &&h, RowView<double> &&hc
             r = (*cnet->r)(ch);
             c = (*cnet->c)(ch);
 
-            H = std::max<double>(0., h(top->j_cont[r][c])) / cos((*top->slope)(r,c)*GTConst::FromDegToRad);
-            Hch = std::max<double>(0., hch(ch) ) / cos((*top->slope)(r,c)*GTConst::FromDegToRad) -
-                  par->depr_channel * cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+            H = std::max<double>(0., h(top->j_cont[r][c])) / cos((*top->slope)(r,c)*GTConst::Pi/180.);
+            Hch = std::max<double>(0., hch(ch) ) / cos((*top->slope)(r,c)*GTConst::Pi/180.) -
+                  par->depr_channel * cos((*top->slope)(r,c)*GTConst::Pi/180.);
 
-            area = ds*ds/cos((*top->slope)(r,c)*GTConst::FromDegToRad) - (*cnet->length)(ch) * par->w_dx * ds;
+            area = ds*ds/cos((*top->slope)(r,c)*GTConst::Pi/180.) - (*cnet->length)(ch) * par->w_dx * ds;
             areach = (*cnet->length)(ch) * par->w_dx * ds;
 
             if (H > par->min_hsup_land)
@@ -2351,16 +2351,16 @@ void supflow_chla(double Dt, double t, RowView<double> &&h, RowView<double> &&hc
 
                     (*Vsup)(ch) += q*dt;
 
-                    h(top->j_cont[r][c]) -= (1.E3 * q*dt/area) * cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                    h(top->j_cont[r][c]) -= (1.E3 * q*dt/area) * cos((*top->slope)(r,c)*GTConst::Pi/180.);
 
                     if (hch(ch)>0)
                     {
-                        hch(ch) += (1.E3 * q*dt/areach) * cos((*top->slope)(r,c)*GTConst::FromDegToRad);  /// [mm]
+                        hch(ch) += (1.E3 * q*dt/areach) * cos((*top->slope)(r,c)*GTConst::Pi/180.);  /// [mm]
                     }
                     else
                     {
                         if ( q > 0 )
-                            hch(ch) = (1.E3 * q*dt/areach) * cos((*top->slope)(r,c)*GTConst::FromDegToRad); /// [mm]
+                            hch(ch) = (1.E3 * q*dt/areach) * cos((*top->slope)(r,c)*GTConst::Pi/180.); /// [mm]
                     }
 
                 }
@@ -2375,15 +2375,15 @@ void supflow_chla(double Dt, double t, RowView<double> &&h, RowView<double> &&hc
 
                     (*Vsup)(ch) += q*dt;
 
-                    h(top->j_cont[r][c]) -= (1.E3 * q*dt/area) * cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                    h(top->j_cont[r][c]) -= (1.E3 * q*dt/area) * cos((*top->slope)(r,c)*GTConst::Pi/180.);
 
                     if (hch(ch)>0)
                     {
-                        hch(ch) += (1.E3 * q*dt/areach) * cos((*top->slope)(r,c)*GTConst::FromDegToRad);  /// [mm]
+                        hch(ch) += (1.E3 * q*dt/areach) * cos((*top->slope)(r,c)*GTConst::Pi/180.);  /// [mm]
                     }
                     else
                     {
-                        if ( q > 0 ) hch(ch) = (1.E3 * q*dt/areach) * cos((*top->slope)(r,c)*GTConst::FromDegToRad); /// [mm]
+                        if ( q > 0 ) hch(ch) = (1.E3 * q*dt/areach) * cos((*top->slope)(r,c)*GTConst::Pi/180.); /// [mm]
                     }
                 }
             }
@@ -2399,15 +2399,15 @@ void supflow_chla(double Dt, double t, RowView<double> &&h, RowView<double> &&hc
 
                 (*Vsup)(ch) -= q*dt;
 
-                hch(ch) -= (1.E3 * q*dt/areach) * cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                hch(ch) -= (1.E3 * q*dt/areach) * cos((*top->slope)(r,c)*GTConst::Pi/180.);
 
                 if (h(top->j_cont[r][c])>0)
                 {
-                    h(top->j_cont[r][c]) += (1.E3 * q*dt/area) * cos((*top->slope)(r,c)*GTConst::FromDegToRad); /// [mm]
+                    h(top->j_cont[r][c]) += (1.E3 * q*dt/area) * cos((*top->slope)(r,c)*GTConst::Pi/180.); /// [mm]
                 }
                 else
                 {
-                    if ( q > 0 ) h(top->j_cont[r][c]) = (1.E3 * q*dt/area) * cos((*top->slope)(r,c)*GTConst::FromDegToRad);  /// [mm]
+                    if ( q > 0 ) h(top->j_cont[r][c]) = (1.E3 * q*dt/area) * cos((*top->slope)(r,c)*GTConst::Pi/180.);  /// [mm]
                 }
             }
         }
@@ -2439,7 +2439,7 @@ void find_dt_max_channel(short DDcomplex, double Courant, RowView<double> &&h,
 
         r = (*cnet->r)(ch);
         c = (*cnet->c)(ch);
-        H = std::max<double>(0., h(ch)) / cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+        H = std::max<double>(0., h(ch)) / cos((*top->slope)(r,c)*GTConst::Pi/180.);
 
         if (H > par->min_hsup_channel)
         {
@@ -2553,7 +2553,7 @@ void channel_flow(double Dt, double t, short DDcomplex, RowView<double> &&h, Vec
 
                 dV[ch] = 0.0;
 
-                H = std::max<double>(0., h(ch)) / cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                H = std::max<double>(0., h(ch)) / cos((*top->slope)(r,c)*GTConst::Pi/180.);
 
                 if (H > par->min_hsup_channel)
                 {
@@ -2601,7 +2601,7 @@ void channel_flow(double Dt, double t, short DDcomplex, RowView<double> &&h, Vec
                 r = (*cnet->r)(ch);
                 c = (*cnet->c)(ch);
 
-                h(ch) -= (1.E3*dV[ch]/(dn*(*cnet->length)(ch))) * cos((*top->slope)(r,c)*GTConst::FromDegToRad);
+                h(ch) -= (1.E3*dV[ch]/(dn*(*cnet->length)(ch))) * cos((*top->slope)(r,c)*GTConst::Pi/180.);
 
                 if ((*top->is_on_border)(r,c) == 1
                     && (*cnet->ch_down)(ch)==ch) /** outlet section */
@@ -2615,13 +2615,13 @@ void channel_flow(double Dt, double t, short DDcomplex, RowView<double> &&h, Vec
                     if (h((*cnet->ch_down)(ch))>0)
                     {
                         h((*cnet->ch_down)(ch)) += (1.E3*dV[ch]/ (dn*(*cnet->length)((*cnet->ch_down)(ch))))
-                                                   * cos( (*top->slope)(R,C)*GTConst::FromDegToRad); /// [mm]
+                                                   * cos( (*top->slope)(R,C)*GTConst::Pi/180.); /// [mm]
                     }
                     else
                     {
                         if ( dV[ch] > 0)
                             h((*cnet->ch_down)(ch)) = (1.E3*dV[ch]/ (dn*(*cnet->length)((*cnet->ch_down)(ch))))
-                                                      * cos((*top->slope)(R,C)*GTConst::FromDegToRad);  /// [mm]
+                                                      * cos((*top->slope)(R,C)*GTConst::Pi/180.);  /// [mm]
                     }
                 }
             }
@@ -2652,7 +2652,7 @@ void draining_land(double alpha, long i, TOPO *T, LAND *L, PAR *P,
 
         r = (*T->rc_cont)(i,1);
         c = (*T->rc_cont)(i,2);
-        H = std::max<double>(h(i), 0.)/cos((*T->slope)(r,c)*GTConst::FromDegToRad);
+        H = std::max<double>(h(i), 0.)/cos((*T->slope)(r,c)*GTConst::Pi/180.);
         p = (*T->Z0)(r,c) + alpha*1.E-3*std::max<double>(h(i), 0.);
         Ks = cm_h((*L->ty)((short)(*L->LC)(r,c),jcm), H, P->thres_hsup_1, P->thres_hsup_2);
 


### PR DESCRIPTION
PR created after noticing that three 3D tests were failing (without MeteoIO):
- Borden05m
- Mazia
- no_reflection.

The executable was able to run but the results were different compared to the 2.0 version.
The reason was numerical differences introduced with the definition of the new variable
```
constexpr double FromDegToRad = Pi/180; /** conversion from degrees to radians */
```

I've tried also to modify the type of the variable (i.e. ```long long``)` but those tests were anyway failing.

[TravisCI didn't tell me this previously since I modified the **.travis.yml** file to check only small_example with MeteoIO => my fault]

